### PR TITLE
Https on sparkpost tr edits

### DIFF
--- a/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
+++ b/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
@@ -80,7 +80,11 @@ The following is a sample guide for use with CloudFlare **only**; please note, t
     
     More information on SSL options for Cloudflare can be found [here](https://support.cloudflare.com/hc/en-us/articles/200170416).
 
-6. For SparkPost customers, turn the page rule ON in your CDN and the process is complete. **Enterprise ONLY** - Reach out to SparkPost support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
+6. For SparkPost customers, turn the page rule ON. **Enterprise ONLY** - Reach out to SparkPost support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
+
+7. Add a CNAME entry into DNS for your tracking domain. The value in the record doesn't matter; the record simply needs to exist. For example, if your tracking domain is `track.example.com`, a CNAME value of `example.com` is sufficient. Without a record to reference, the the page rule never gets triggered, and the proper redirection will not occur.
+
+8. Navigate to the Tracking Domains section in the UI and click the orange "test" verification link. At this point, the process is complete.
 
 ## Additional Resources for Content Delivery Networks
 

--- a/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
+++ b/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
@@ -80,7 +80,7 @@ The following is a sample guide for use with CloudFlare **only**; please note, t
     
     More information on SSL options for Cloudflare can be found [here](https://support.cloudflare.com/hc/en-us/articles/200170416).
 
-6. Reach out to SparkPost Support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
+6. **Enterprise ONLY** - Reach out to SparkPost support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
 
 ## Additional Resources for Content Delivery Networks
 

--- a/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
+++ b/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
@@ -19,7 +19,7 @@ In addition to SSL certificates, link forwarding, and page rules (see the step b
 
 ## How to Switch a Tracking Domain from Insecure to Secure
 
-If you have previously created a tracking domain (whether verified or unverified), and wish to switch it from insecure (the default value for tracking domains) to secure, use the tracking domains API `PUT` call to update the tracking domain with `"secure": true`. Detailed information on this operation can be found in our API documentation [here](https://developers.sparkpost.com/api/tracking-domains.html#tracking-domains-retrieve,-update,-and-delete-put).
+If you have previously created a tracking domain (whether verified or unverified), and wish to switch it from insecure (the default value for tracking domains) to secure, use the tracking domains API `PUT` call to update the tracking domain with the `"secure": true` string. Detailed information on this operation can be found in our API documentation [here](https://developers.sparkpost.com/api/tracking-domains.html#tracking-domains-retrieve,-update,-and-delete-put).
 
 ## Step by Step Guide with CloudFlare
 

--- a/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
+++ b/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
@@ -15,11 +15,11 @@ As a workaround, you may use a Content Delivery Network (CDN) service, such as [
 
 ## How to Create a Secure Tracking Domain on SparkPost
 
-In addition to SSL certificates, link forwarding, and page rules (see the step by step guide below), you will need to create a tracking domain with the tracking domains API using the `"secure": true` string. Detailed information on this operation can be found in our API documentation [here]https://developers.sparkpost.com/api/tracking-domains.html#tracking-domains-create-and-list-post.
+In addition to SSL certificates, link forwarding, and page rules (see the step by step guide below), you will need to create a tracking domain with the tracking domains API using the `"secure": true` string. Detailed information on this operation can be found in our API documentation [here](https://developers.sparkpost.com/api/tracking-domains.html#tracking-domains-create-and-list-post).
 
 ## How to Switch a Tracking Domain from Insecure to Secure
 
-If you have previously created a tracking domain (whether verified or unverified), and wish to switch it from insecure (the default value for tracking domains) to secure, use the tracking domains API `PUT` call to update the tracking domain with `"secure": true`. Detailed information on this operation can be found in our API documentation [here]https://developers.sparkpost.com/api/tracking-domains.html#tracking-domains-retrieve,-update,-and-delete-put.
+If you have previously created a tracking domain (whether verified or unverified), and wish to switch it from insecure (the default value for tracking domains) to secure, use the tracking domains API `PUT` call to update the tracking domain with `"secure": true`. Detailed information on this operation can be found in our API documentation [here](https://developers.sparkpost.com/api/tracking-domains.html#tracking-domains-retrieve,-update,-and-delete-put).
 
 ## Step by Step Guide with CloudFlare
 

--- a/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
+++ b/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
@@ -67,7 +67,7 @@ The following is a sample guide for use with CloudFlare **only**; please note, t
 4. Create the appropriate page rule settings for the domain. In the page rules tab, perform the following instructions:
     * Page Rule Tab -> Create Page Rule
     * Enter your domain like so: `track.yourdomain.com/*`
-    * Add a Setting -> Forwarding URL
+    * Add a Setting -> Forwarding URL (you may need to specify a 301 redirect option)
     * Destination URL is https://spgo.io/$1
     * Save and Deploy (turn page rule on)
     
@@ -82,7 +82,7 @@ The following is a sample guide for use with CloudFlare **only**; please note, t
 
 6. For SparkPost customers, turn the page rule ON. **Enterprise ONLY** - Reach out to SparkPost support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
 
-7. Add a CNAME entry into DNS for your tracking domain. The value in the record doesn't matter; the record simply needs to exist. For example, if your tracking domain is `track.example.com`, a CNAME value of `example.com` is sufficient. Without a record to reference, the the page rule never gets triggered, and the proper redirection will not occur.
+7. **Note: This step is if you host your own certificate. If you are a SparkPost Enterprise customer, there is an option for us to host your certifcate, but the preferred method is self-hosting.** Add a CNAME entry into DNS for your tracking domain. The value in the record doesn't matter; the record simply needs to exist. For example, if your tracking domain is `track.example.com`, a CNAME value of `example.com` is sufficient. Without a record to reference, the the page rule never gets triggered, and the proper redirection will not occur. Please note that the typical time to progagation of new CNAME records is often around five to ten minutes, but can be longer depending on your DNS provider.
 
 8. Navigate to the Tracking Domains section in the UI and click the orange "test" verification link. At this point, the process is complete.
 

--- a/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
+++ b/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
@@ -80,7 +80,7 @@ The following is a sample guide for use with CloudFlare **only**; please note, t
     
     More information on SSL options for Cloudflare can be found [here](https://support.cloudflare.com/hc/en-us/articles/200170416).
 
-6. **Enterprise ONLY** - Reach out to SparkPost support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
+6. For SparkPost customers, turn the page rule ON in your CDN and the process is complete. **Enterprise ONLY** - Reach out to SparkPost support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
 
 ## Additional Resources for Content Delivery Networks
 

--- a/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
+++ b/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
@@ -64,12 +64,14 @@ The following is a sample guide for use with CloudFlare **only**; please note, t
     	;; MSG SIZE  rcvd: 88
     ```
 
-4. Navigate to the Page Rules settings for the domain and perform the following instructions.
+4. Create the appropriate page rule settings for the domain. In the page rules tab, perform the following instructions:
     * Page Rule Tab -> Create Page Rule
     * Enter your domain like so: `track.yourdomain.com/*`
     * Add a Setting -> Forwarding URL
     * Destination URL is https://spgo.io/$1
-    * Save and Deploy
+    * Save and Deploy (turn page rule on)
+    
+    ![](media/enabling-https-engagement-tracking-on-sparkpost/SSL_full.png)
     
 5. Cloudflare has Universal SSL for all accounts, but it's good to ensure that setting on the page rule is "SSL". This is required for how CloudFlare will validate the certificate on the origin.
 
@@ -78,11 +80,7 @@ The following is a sample guide for use with CloudFlare **only**; please note, t
     
     More information on SSL options for Cloudflare can be found [here](https://support.cloudflare.com/hc/en-us/articles/200170416).
 
-6. Turn the page rule "on."
-
-    ![](media/enabling-https-engagement-tracking-on-sparkpost/SSL_full.png)
-
-7. Reach out to SparkPost Support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
+6. Reach out to SparkPost Support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
 
 ## Additional Resources for Content Delivery Networks
 

--- a/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
+++ b/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
@@ -13,6 +13,14 @@ In order for HTTPS engagement tracking to be enabled on SparkPost, our service n
 
 As a workaround, you may use a Content Delivery Network (CDN) service, such as [Cloudflare](http://www.cloudflare.com) or [Fastly](http://www.fastly.com) to manage certificates and keys for any custom engagement tracking domains you configure.  These services forward traffic onwards to SparkPost so that HTTPS tracking can be performed.
 
+## How to Create a Secure Tracking Domain on SparkPost
+
+In addition to SSL certificates, link forwarding, and page rules (see the step by step guide below), you will need to create a tracking domain with the tracking domains API using the `"secure": true` string. Detailed information on this operation can be found in our API documentation [here]https://developers.sparkpost.com/api/tracking-domains.html#tracking-domains-create-and-list-post.
+
+## How to Switch a Tracking Domain from Insecure to Secure
+
+If you have previously created a tracking domain (whether verified or unverified), and wish to switch it from insecure (the default value for tracking domains) to secure, use the tracking domains API `PUT` call to update the tracking domain with `"secure": true`. Detailed information on this operation can be found in our API documentation [here]https://developers.sparkpost.com/api/tracking-domains.html#tracking-domains-retrieve,-update,-and-delete-put.
+
 ## Step by Step Guide with CloudFlare
 
 The following is a sample guide for use with CloudFlare **only**; please note, the steps to configure your chosen CDN will likely differ from CloudFlare in workflow. Please refer to your CDN's documentation and contact their respective support departments if you have any questions.
@@ -56,32 +64,25 @@ The following is a sample guide for use with CloudFlare **only**; please note, t
     	;; MSG SIZE  rcvd: 88
     ```
 
-4. Add a new CNAME entry that points your domain to `spgo.io`:
-
-    **Example:**
-
-    Using an engagement tracking domain of `track.example.com` in SparkPost, the appropriate CNAME record under the DNS tab of CloudFlare has been added.
-
-    ![](media/enabling-https-engagement-tracking-on-sparkpost/CNAMEtospgoio.png)
-
-5. Navigate to the Page Rules settings for the domain.
+4. Navigate to the Page Rules settings for the domain and perform the following instructions.
     * Page Rule Tab -> Create Page Rule
-    * Enter your domain like so: track.yourdomain.com/*
+    * Enter your domain like so: `track.yourdomain.com/*`
     * Add a Setting -> Forwarding URL
     * Destination URL is https://spgo.io/$1
     * Save and Deploy
     
-6. Cloudflare has Universal SSL for all accounts, but it's good to ensure that setting on the page rule is "SSL". This is required for how CloudFlare will validate the certificate on the origin.
+5. Cloudflare has Universal SSL for all accounts, but it's good to ensure that setting on the page rule is "SSL". This is required for how CloudFlare will validate the certificate on the origin.
 
     ![](media/enabling-https-engagement-tracking-on-sparkpost/page_rule.png)
 
+    
     More information on SSL options for Cloudflare can be found [here](https://support.cloudflare.com/hc/en-us/articles/200170416).
 
-7. Turn the page rule "on."
+6. Turn the page rule "on."
 
     ![](media/enabling-https-engagement-tracking-on-sparkpost/SSL_full.png)
 
-8. Reach out to SparkPost Support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
+7. Reach out to SparkPost Support and request that HTTPS engagement tracking be enabled on your account. They will verify the configuration and enable the setting on your account.
 
 ## Additional Resources for Content Delivery Networks
 

--- a/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
+++ b/articles/tech-resources/enabling-https-engagement-tracking-on-sparkpost.md
@@ -65,7 +65,13 @@ The following is a sample guide for use with CloudFlare **only**; please note, t
     ![](media/enabling-https-engagement-tracking-on-sparkpost/CNAMEtospgoio.png)
 
 5. Navigate to the Page Rules settings for the domain.
-6. Create a page rule for the domain that sets SSL to “Full”. This is required for how CloudFlare will validate the certificate on the origin.
+    * Page Rule Tab -> Create Page Rule
+    * Enter your domain like so: track.yourdomain.com/*
+    * Add a Setting -> Forwarding URL
+    * Destination URL is https://spgo.io/$1
+    * Save and Deploy
+    
+6. Cloudflare has Universal SSL for all accounts, but it's good to ensure that setting on the page rule is "SSL". This is required for how CloudFlare will validate the certificate on the origin.
 
     ![](media/enabling-https-engagement-tracking-on-sparkpost/page_rule.png)
 


### PR DESCRIPTION
I've made the changes, but the CDOC-122 ticket mentions "Cloudflare already has universal SSL", so I was confused on whether or not you wanted a portion of this article still retained. Specifically, this instruction in the list:


5. Cloudflare has Universal SSL for all accounts, but it's good to ensure that setting on the page rule is "SSL". This is required for how CloudFlare will validate the certificate on the origin.

    ![](media/enabling-https-engagement-tracking-on-sparkpost/page_rule.png)

    
    More information on SSL options for Cloudflare can be found [here](https://support.cloudflare.com/hc/en-us/articles/200170416).

The SSL options page link at Cloudflare is still live, and the current version of the article shows several options. I know we want some version of "full" on their settings, but do we want FULL SSL or FULL (STRICT)? If full (strict), I'll have to ditch the current screenshot, and I don't have a Cloudflare account to create a new one. I don't really think that's a big deal since it looks like it's pretty prominently displayed on the rules page according to the existing doc screenshots.

I also wanted to ask this question since the CDOC's steps for creating the page rules for the domain did *not* include setting the SSL option. Can you please clarify on these two points and I'll finalize? Thanks.