### PR TITLE
Update sending-attachments.md

### DIFF
--- a/articles/user-guide/sending-attachments.md
+++ b/articles/user-guide/sending-attachments.md
@@ -1,5 +1,5 @@
 ---
-title: "Sending Attachments in SparkPost and SparkPost Enterprise"
+title: "Sending Attachments"
 description: "A transmission is a collection of messages belonging to the same campaign It is also known as a mailing The Transmissions API provides the means to manage transmissions Messages in the transmissions are generated and sent to a specified list of recipients using a specified message template The recipient list..."
 ---
 
@@ -12,17 +12,23 @@ A transmission is a collection of messages belonging to the same campaign. It is
 
 In addition, engagement tracking options can be set in the transmission to track message opens and clicks.
 
-## Attachments Support in the API
+## Attachments Support in SMTP API
+
+You can embed the attachment within your standard RFC-822 content and send via SMTP.  
+
+## Attachments Support in the Transmissions API
 
 We have added support for attachments using the Transmissions API. Attachments can be any file type or inline images. In a future enhancement, we will include file type validation.
 
 A few notes about this feature:
 
 * There is a 20 MB content size limit on each message, including content body and all attachments
-* **Attachments are supported with inline templates only.** A future enhancement will include support for attachments with stored templates.
+* **Attachments are supported with inline templates only.** We may include support for attachments with stored templates in the future.
 
 ## Attributes
 
 Attachments for a transmission are specified in the `content.attachments` JSON array where each JSON object in the array is described [here](https://developers.sparkpost.com/api/transmissions.html#header-attachment-attributes).
 
 Inline images for a transmission are specified in the `content.inline_images` JSON array where each JSON object in the array is described [here](https://developers.sparkpost.com/api/transmissions.html#header-inline-image-attributes).
+
+Alternatively, if you have a fixed attachment you can embed it witin the email_rfc822 attribute, see [Sending RFC-822 content](https://developers.sparkpost.com/api/transmissions/#transmissions-post-send-rfc822-content)


### PR DESCRIPTION
* removed the redundant "SparkPost and SparkPost Enterprise" in title.
* Added info on sending attachments using the SMTP API
* Added info on sending attachments using the Transmissions API with RFC-822 content

### Support Docs Update Checklist

Note: when you open a pull request, your changes are published to https://staging.sparkpost.com/docs.

Please take a moment to check each of these steps for your pull request:

- [ ] Give your pull request a meaningful name.
- [ ] Include a description of your changes in the pull request.
- [ ] _SparkPost staff only_: Check that your article appears [here](https://staging.sparkpost.com/docs) and looks correct.
- [ ] Check the links in your article.
- [ ] Use lowercase filenames.
