### PR TITLE
TR-2048 Update max RV batch file size to 20mb

### DIFF
--- a/articles/recipient-validation/validate-an-email-list.md
+++ b/articles/recipient-validation/validate-an-email-list.md
@@ -13,7 +13,7 @@ Before uploading your list, make sure it fits the following conditions:
 * The file type is `.csv` or `.txt`
 * The file does not contain a header row
 * Each line should contain a single email address, with no additional columns
-* Your file should be under the maximum size of `200MB`
+* Your file should be under the maximum size of `20MB`
 
 Below is an example of a valid file to upload:
 


### PR DESCRIPTION
### Support Docs Update Checklist
Current RV batch file size is 200mb; which has never been tested.  After testing in TR-2044, it's been decided that 20mb is a size that has not failed (to date), and is safer for our system.

**Link location updating:** https://www.sparkpost.com/docs/recipient-validation/validate-an-email-list/