### PR TITLE
adds explanation of supported ports for webhooks

### DIFF
--- a/support/faq/post-to-webhook-target-failed.md
+++ b/support/faq/post-to-webhook-target-failed.md
@@ -11,5 +11,6 @@ This error occurs when SparkPost sends a test batch to your webhook endpoint and
 
 * Webhooks require you to publish an HTTP service (the "target URL" above) to receive event data.  Your service must be in place *before* you register the webhook with SparkPost.
 * Your receiving HTTP service must return a 200 status code when it successfully receives an event batch.  Any non 200 response is treated as an error.
+* For security reasons, SparkPost only supports standard ports 80 (for HTTP traffic) and 443 (for HTTPS traffic). Make sure your webhook endpoint is listening for traffic on at least one of these ports.
 
 For more details on managing your webhooks and handling webhook event data, check out [this support article](https://www.sparkpost.com/docs/tech-resources/managing-webhook-data/) and [this blog post](https://www.sparkpost.com/blog/webhooks-beyond-the-basics/) on the topic.


### PR DESCRIPTION
For security purposes webhooks only support ports :80 and :443. This adds a note to the creation endpoint explaining what ports we support.

See https://github.com/SparkPost/developers.sparkpost.com/pull/433 for API documentation updates.