### PR TITLE
FE-1406: Resolve Dependabot alerts for support-docs

### DIFF
--- a/bin/package-lock.json
+++ b/bin/package-lock.json
@@ -52,12 +52,9 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-4.0.0.tgz",
-      "integrity": "sha1-6H+1VD4BllrfcVBsa/ewSRhBt+M=",
-      "requires": {
-        "string": "^3.3.3"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz",
+      "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg=="
     },
     "markdown-it-meta": {
       "version": "0.0.1",
@@ -76,11 +73,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "string": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
-      "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/bin/package.json
+++ b/bin/package.json
@@ -5,7 +5,7 @@
   "author": "SparkPost",
   "dependencies": {
     "markdown-it": "^8.3.1",
-    "markdown-it-anchor": "^4.0.0",
+    "markdown-it-anchor": "^5.0.2",
     "markdown-it-meta": "0.0.1"
   }
 }


### PR DESCRIPTION
To resolve https://github.com/SparkPost/support-docs/security/dependabot/bin/package-lock.json/string/open, bumped markdown-it-anchor to v5.0.2.  In v5, markdown-it-anchor "drop string package in favour of encodeURIComponent"  see [CHANGELOG](https://github.com/valeriangalliat/markdown-it-anchor/blob/master/CHANGELOG.md).
