### PR TITLE
TR-3159 sandbox domain abuse extended error code

### DIFF
--- a/support/tech-resources/extended-error-codes.md
+++ b/support/tech-resources/extended-error-codes.md
@@ -56,7 +56,7 @@ The following table is a complete list of extended error code responses, organiz
 |                       | 2101        | Exceed Sending Limit (hourly)                    | 420              |                                              |
 |                       | 2102        | Exceed Sending Limit (daily)                     | Deprecated       |                                              |
 |                       | 2103        | Exceed Sending Limit (sandbox)                   | 420              |                                              |
-|                       | 2106        | Invalid template for sandbox domain              | 422              |                                              |
+|                       | 2106        | Invalid template ID (sandbox)                    | 422              |                                              |
 | *Template*            | *3000~3999* |                                                  |                  |                                              |
 |                       | 3000        | template language syntax error                   | 422              | fix content and retry                        |
 |                       | 3001        | template language render error                   | 422              | fix content and retry                        |

--- a/support/tech-resources/extended-error-codes.md
+++ b/support/tech-resources/extended-error-codes.md
@@ -56,6 +56,7 @@ The following table is a complete list of extended error code responses, organiz
 |                       | 2101        | Exceed Sending Limit (hourly)                    | 420              |                                              |
 |                       | 2102        | Exceed Sending Limit (daily)                     | Deprecated       |                                              |
 |                       | 2103        | Exceed Sending Limit (sandbox)                   | 420              |                                              |
+|                       | 2106        | Invalid template for sandbox domain              | 422              |                                              |
 | *Template*            | *3000~3999* |                                                  |                  |                                              |
 |                       | 3000        | template language syntax error                   | 422              | fix content and retry                        |
 |                       | 3001        | template language render error                   | 422              | fix content and retry                        |

--- a/support/tech-resources/extended-error-codes.md
+++ b/support/tech-resources/extended-error-codes.md
@@ -56,7 +56,7 @@ The following table is a complete list of extended error code responses, organiz
 |                       | 2101        | Exceed Sending Limit (hourly)                    | 420              |                                              |
 |                       | 2102        | Exceed Sending Limit (daily)                     | Deprecated       |                                              |
 |                       | 2103        | Exceed Sending Limit (sandbox)                   | 420              |                                              |
-|                       | 2106        | Invalid template ID (sandbox)                    | 422              |                                              |
+|                       | 2106        | Invalid Template ID (sandbox)                    | 422              |                                              |
 | *Template*            | *3000~3999* |                                                  |                  |                                              |
 |                       | 3000        | template language syntax error                   | 422              | fix content and retry                        |
 |                       | 3001        | template language render error                   | 422              | fix content and retry                        |


### PR DESCRIPTION
### Changes
- Added 2106 as an extended error code for Transmissions for not using the default template in the sandbox domain

### Support Docs Update Checklist

Note: when you open a pull request, your changes are published to https://staging.sparkpost.com/docs.

Please take a moment to check each of these steps for your pull request:

- [x] Give your pull request a meaningful name.
- [x] Include a description of your changes in the pull request.
- [ ] _SparkPost staff only_: Check that your article appears [here](https://staging.sparkpost.com/docs) and looks correct.
- [x] Check the links in your article. N/a
- [x] Use lowercase filenames.
