### PR TITLE
Improve PowerMTA relay to SparkPost article

### DIFF
--- a/support/integrations/power-mta.md
+++ b/support/integrations/power-mta.md
@@ -32,7 +32,7 @@ The `{sparkpost}` directive is a short way to get the needed configuration.
 The config can optionally select a particular SparkPost dedicated IP pool by name, or select a SparkPost subaccount for delivery. See PowerMTA User Guide "SparkPost Traffic Redirection Support" for more information.
 
 
-Benefits of using PMTA to relay to SparkPost:
+Benefits of using PowerMTA to relay to SparkPost:
 * You don’t need to change your existing message generation architecture:
     * PowerMTA handles all the queueing and any network issues that might arise during delivery.
     * Your message generation platform may not supply a SMTP username and password, particularly if it's directly connected to your MTA over a private network. Any cloud sending service expects authentication; PowerMTA can supply the username and password on the outgoing connection.
@@ -44,9 +44,9 @@ Benefits of using PMTA to relay to SparkPost:
 
 ## Selecting domains to relay to SparkPost
 
-The `<domain *>` directive shown above causes all mail to be sent to SparkPost. More realistically, you will want to migrate gradually, by selecting which traffic streams go to SparkPost, and which ones are delivered by PMTA as before. With PMTA, you can select based on the `MAIL FROM` domain (known as the sending domain in SparkPost).
+The `<domain *>` directive shown above causes all mail to be sent to SparkPost. More realistically, you will want to migrate gradually, by selecting which traffic streams go to SparkPost, and which ones are delivered by PowerMTA as before. With PowerMTA, you can select based on the `MAIL FROM` domain (known as the sending domain in SparkPost).
 
-In your PMTA configuration, include a `pattern-list` into the source directive that receives your incoming messages.  For example:
+In your PowerMTA configuration, include a `pattern-list` into the source directive that receives your incoming messages.  For example:
 
 ```
 # Settings per source IP address (for incoming SMTP connections)

--- a/support/integrations/power-mta.md
+++ b/support/integrations/power-mta.md
@@ -16,7 +16,7 @@ Now [create and verify](https://app.sparkpost.com/account/sending-domains) the d
 
 Add the following to your PowerMTA config, changing the value for auth-password to the SparkPost API key you created above.
 
-The `{sparkpost}` directive is a short way to get the needed configuration.
+The `{sparkpost}` special domain is a short way to get the needed configuration.
 
 ```
 <domain {sparkpost}>

--- a/support/integrations/power-mta.md
+++ b/support/integrations/power-mta.md
@@ -11,27 +11,38 @@ Next, [create an API key](https://app.sparkpost.com/account/credentials) with th
 
 Now [create and verify](https://app.sparkpost.com/account/sending-domains) the domain you want to use for sending. The setup process should take about 5-10 minutes if you have access to your DNS server. See [Verify Sending Domains](https://www.sparkpost.com/docs/getting-started/getting-started-sparkpost/#step-2-verifying-domain-ownership) for more information.
 
-Add the following to your PowerMTA config, changing the value for auth-password to the SparkPost API key you created above:
+
+## PowerMTA basic configuration
+
+Add the following to your PowerMTA config, changing the value for auth-password to the SparkPost API key you created above.
+
+The `{sparkpost}` directive is a short way to get the needed configuration.
 
 ```
-<domain sparkpost.rollup>
- use-unencrypted-plain-auth yes
- auth-username SMTP_Injection
- auth-password xxxxxxxx
- route smtp.sparkpostmail.com:587
- use-starttls yes
- require-starttls yes
- max-smtp-out 10
+<domain {sparkpost}>
+    auth-password ###YOUR API KEY HERE###           # generate under Account/API Keys
+    sparkpost-ip-pool test                          # if you want to select a specific SparkPost IP pool
 </domain>
 
 <domain *>
- queue-to sparkpost.rollup
+ queue-to {sparkpost}
 </domain>
 ```
 
-Two great benefits of using PowerMTA to relay to SparkPost are you don’t need to change your existing architecture, and PowerMTA handles all the queueing and any network issues that might arise during delivery.You also get the excellent [built in metrics](https://app.sparkpost.com/reports/summary) that are part of SparkPost.
+The config can optionally select a particular SparkPost dedicated IP pool by name, or select a SparkPost subaccount for delivery. See PowerMTA User Guide "SparkPost Traffic Redirection Support" for more information.
 
-## Selecting which domains to send through SparkPost
+
+Benefits of using PMTA to relay to SparkPost:
+* You don’t need to change your existing message generation architecture:
+    * PowerMTA handles all the queueing and any network issues that might arise during delivery.
+    * Your message generation platform may not supply a SMTP username and password, particularly if it's directly connected to your MTA over a private network. Any cloud sending service expects authentication; PowerMTA can supply the username and password on the outgoing connection.
+    * PowerMTA supports TLS, ensuring the outgoing connection is secure.
+
+* PowerMTA supports multiple connections, which provides fast message injection to SparkPost.
+
+* You get the [built in analytics](https://app.sparkpost.com/reports/summary) and event reporting that are part of SparkPost.
+
+## Selecting domains to relay to SparkPost
 
 The `<domain *>` directive shown above causes all mail to be sent to SparkPost. More realistically, you will want to migrate gradually, by selecting which traffic streams go to SparkPost, and which ones are delivered by PMTA as before. With PMTA, you can select based on the `MAIL FROM` domain (known as the sending domain in SparkPost).
 
@@ -68,11 +79,4 @@ Next, we set up a virtual-mta to handle this traffic with your chosen name. In t
 </virtual-mta>
 ```
 
-The `{sparkpost}` directive is a short way to get the needed configuration, instead of giving all the details in the  `<domain sparkpost.rollup>` directive in the first example. We can also select a particular SparkPost dedicated IP pool by name.  See PMTA User Guide section 3.3.20 "SparkPost Traffic Redirection Support".
-
-```
-<domain {sparkpost}>
-    auth-password ###YOUR API KEY HERE###           # generate under Account/API Keys
-    sparkpost-ip-pool test                          # if you want to select a specific SparkPost IP pool
-</domain>
-```
+See also: [Hybrid Cloud: Migrating Traffic Streams Smoothly from PowerMTA to SparkPost](https://www.sparkpost.com/blog/hybrid-cloud-migrating-traffic-streams-smoothly-from-powermta-to-sparkpost/).


### PR DESCRIPTION
Improved the first example to use the new directive style.
Added more explanation of benefits.
Changed PMTA -> PowerMTA 