### PR TITLE
WE-289 Render initial stylesheets on server

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
+
+/**
+ * See: https://nextjs.org/docs/advanced-features/custom-document
+ */
+class AppDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet();
+    const originalRenderPage = ctx.renderPage;
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+        });
+
+      const initialProps = await Document.getInitialProps(ctx);
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      };
+    } finally {
+      sheet.seal();
+    }
+  }
+
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default AppDocument;


### PR DESCRIPTION
**What Changed**
- Collects application styles and generates them on the server instead of in the browser


**How to verify**
- There is no way to verify this locally, **use the deploy preview to verify**
- Verify that on first load, with a hard refresh, CSS styles do no pop in (things should render in their finals styles on first load)