### PR TITLE
WE-300: copy over security badger

### DIFF
--- a/.github/workflows/security-badger.yml
+++ b/.github/workflows/security-badger.yml
@@ -2,9 +2,6 @@ name: Security Badger
 
 on:
   workflow_dispatch: # Allows manual triggering - this can be removed after stabilization
-  push:
-    branches:
-      - WE-300-copy-over-security-badger
   schedule:
     # Run every Thursday at 6:00 PM UTC
     - cron: '0 18 * * 4'


### PR DESCRIPTION
### What changed

Adds the security badger github action to the next project. 

### How to test
There's a few ways we can do this. The best is going to be 
- wait until Fri. Oct 22nd and see if the workflow was triggered (the workflow is triggered to run every Thursday at 6:00 PM UTC)
- Manually run the action or verify from previously run tests: https://github.com/SparkPost/support-docs/actions/workflows/security-badger.yml

### Notes
I noticed that one of the tests I ran had a 403 error. I'll bet that this is because we've blocked the reporting from support-docs since it hasn't been working for some time now. I'll need to verify with the FE team, but we won't want to unblock it until we launch the site since the `master` branch of support-docs is still busted and applied.