### PR TITLE
WE-324 Fix site layout responsiveness

### DIFF
--- a/components/markdown/image.tsx
+++ b/components/markdown/image.tsx
@@ -29,7 +29,7 @@ const Image = (props: ImageProps): JSX.Element | null => {
   return (
     <Box position="relative" display="flex" justifyContent="center" width="100%" my="600">
       {/* Not using Next.js's image component because it doesn't support dynamic aspect ratios */}
-      <Box as="img" src={imageSrc} alt={alt} width="auto" maxHeight="500px" />
+      <Box as="img" src={imageSrc} alt={alt} width="auto" maxWidth="100%" maxHeight="500px" />
     </Box>
   );
 };

--- a/components/site/footer.tsx
+++ b/components/site/footer.tsx
@@ -27,7 +27,7 @@ const Footer = (): JSX.Element => {
       display="flex"
       justifyContent="center"
     >
-      <Box width="100%" maxWidth="945px">
+      <Box width="100%" maxWidth="1400" px="400">
         {/* Waiting on Copy */}
         {/* <Box fontSize="400" lineHeight="400" pb="200" fontWeight="semibold">Turpis nunc eget lorem dolor sed viverra ipsum</Box>
         <Box fontSize="400" lineHeight="400" pb="450">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Arcu vitae elementum curabitur vitae.</Box>

--- a/components/site/layout.tsx
+++ b/components/site/layout.tsx
@@ -22,8 +22,8 @@ const StyledSkipToContent = styled(Box)<BoxProps>`
 const Layout = (props: LayoutProps): JSX.Element => {
   const { children, navigationComponent } = props;
   return (
-    <Box display="flex" flexDirection="column" minHeight="100vh">
-      <Box display="flex" justifyContent="center" bg="gray.100" flex="1">
+    <Box display="flex" flexDirection="column" minHeight="100vh" bg="gray.100">
+      <Box flex="1" mx="auto" px="400" maxWidth="1400" width="100%">
         <div>
           <StyledSkipToContent
             as="a"
@@ -38,7 +38,7 @@ const Layout = (props: LayoutProps): JSX.Element => {
             Skip to main content
           </StyledSkipToContent>
           <Header />
-          <Box display="flex" maxWidth="1400" bg="white" border="400">
+          <Box display="flex" width="100%" bg="white" border="400">
             <Box flex="0">{navigationComponent}</Box>
             <Box
               p="500"


### PR DESCRIPTION
**What Changed**
- Adjusts some styles on the layout and markdown image

**How to verify**
- Run the site or deploy preview
- Visit the momentum home page, or any other post page
- Layout container should expand to `1400` and flex with the browser's viewport