### PR TITLE
WE-67 Add support doc algolia indexing and search input

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -40,7 +40,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Index Momentum Posts
-        run: npm run build:index:momentum
+        run: npm run build:index:momentum && npm run build:index:support
         env:
           NEXT_PUBLIC_ALGOLIA_APP_ID: ${{secrets.NEXT_PUBLIC_ALGOLIA_APP_ID}}
           ALGOLIA_SEARCH_ADMIN_KEY: ${{secrets.ALGOLIA_SEARCH_ADMIN_KEY}}

--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -39,7 +39,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       # Runs a single command using the runners shell
-      - name: Index Momentum Posts
+      - name: Index Posts
         run: npm run build:index:momentum && npm run build:index:support
         env:
           NEXT_PUBLIC_ALGOLIA_APP_ID: ${{secrets.NEXT_PUBLIC_ALGOLIA_APP_ID}}

--- a/components/site/algolia/search.tsx
+++ b/components/site/algolia/search.tsx
@@ -6,7 +6,7 @@ import SearchBox from 'components/site/algolia/searchBox';
 import SearchResults from 'components/site/algolia/results';
 
 type SearchProps = {
-  indexName: 'next_momentum_documentation';
+  indexName: 'next_momentum_documentation' | 'next_support_documentation';
 };
 
 const Search = (props: SearchProps): JSX.Element => {

--- a/components/site/header.tsx
+++ b/components/site/header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useRouter } from 'next/router';
-import { Box, Button, TextField } from '@sparkpost/matchbox';
-import { Search as SearchIcon, OpenInNew } from '@sparkpost/matchbox-icons';
+import { Box, Button } from '@sparkpost/matchbox';
+import { OpenInNew } from '@sparkpost/matchbox-icons';
 import Cookies from 'js-cookie';
 import Logo from 'components/site/logo';
 import Search from 'components/site/algolia/search';
@@ -44,12 +44,7 @@ const Header = () => {
         {category === 'momentum' ? (
           <Search indexName="next_momentum_documentation" />
         ) : (
-          <TextField
-            id="algolia-search"
-            label="Search"
-            prefix={<SearchIcon />}
-            placeholder="e.g. Getting Started"
-          />
+          <Search indexName="next_support_documentation" />
         )}
       </Box>
     </Box>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "next build",
     "build:ssr": "next build && next export",
     "build:index:momentum": "node ./scripts/momentumIndex.mjs",
+    "build:index:support": "node ./scripts/supportIndex.mjs",
     "build:images": "rimraf public/content && node ./scripts/copyImages.mjs",
     "postbuild": "next-sitemap",
     "start": "next start",

--- a/scripts/algoliaIndex.mjs
+++ b/scripts/algoliaIndex.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import algoliasearch from 'algoliasearch';
+import dotenv from 'dotenv';
+import { remark } from 'remark';
+import strip from 'strip-markdown';
+
+function transformPostToSearchObject(post) {
+  const content = remark().use(strip).processSync(post.content);
+  const excerpt = String(content).replace(/\n/g, ' ').substring(0, 200);
+
+  return {
+    objectID: post.file,
+    slug: post.url,
+    title: post.data.title,
+    description: post.data.description,
+    excerpt,
+  };
+}
+
+export async function buildIndex(indexName, getPosts) {
+  dotenv.config();
+  const appId = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID;
+  const adminKey = process.env.ALGOLIA_SEARCH_ADMIN_KEY;
+
+  if (!appId && !adminKey) {
+    console.error('Algolia credentials missing.');
+    process.exit(1);
+  }
+
+  try {
+    const client = algoliasearch(appId, adminKey);
+    const index = client.initIndex(indexName);
+    const posts = getPosts();
+    const transformed = posts.map(transformPostToSearchObject);
+
+    const algoliaResponse = await index.saveObjects(transformed);
+    console.log(`Added ${algoliaResponse.objectIDs.length} records to Algolia search`);
+    process.exit();
+  } catch (error) {
+    console.log(error);
+    process.exit(1);
+  }
+}

--- a/scripts/supportIndex.mjs
+++ b/scripts/supportIndex.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import glob from 'glob';
+import matter from 'gray-matter';
+import { buildIndex } from './algoliaIndex.mjs';
+
+const getAllSupportPosts = () => {
+  return glob.sync(`content/docs/**/!(index).md`).map((file) => {
+    const withoutExtensions = file.replace(/.md$/, '');
+    const url = withoutExtensions.replace(/^content\//, '/');
+    const filePath = path.join(path.join(process.cwd(), 'content'), `${url}.md`);
+
+    if (fs.existsSync(filePath)) {
+      return { url, file, ...matter(fs.readFileSync(filePath, 'utf8')) };
+    }
+  });
+};
+
+(async function () {
+  buildIndex('next_support_documentation', getAllSupportPosts);
+})();


### PR DESCRIPTION
**What Changed**
- Abstracts out some bits of the Algolia indexing script for reuse
- Adds a script for indexing support documentation
- Creates a new Algolia index for support docs called `next_support_documentation`
- Updates the Search component to accept this new index

**How to verify**
- Verify the index is populated in Algolia
- Visit the deploy preview and verify the search input works