### PR TITLE
WE-335: netlify redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+# A redirect rule with many of the supported properties
+[[redirects]]
+  from = "/"
+  to = "/docs"
+
+  # By default, redirects won’t be applied if there’s a file with the same
+  # path as the one defined in the `from` property. Setting `force` to `true`
+  # will make the redirect rule take precedence over any existing files.
+  force = true


### PR DESCRIPTION
### What Changed
Adds a netlify.toml file with the redirect we need netlify to honor.

### How to test
- go to https://deploy-preview-592--support-docs.netlify.app/
- verify it redirects to https://deploy-preview-592--support-docs.netlify.app/docs