### PR TITLE
WE-337 add bottom margin and horizontal padding to table

### DIFF
--- a/components/markdown/table.tsx
+++ b/components/markdown/table.tsx
@@ -1,4 +1,4 @@
-import { Panel, Table as MBTable } from '@sparkpost/matchbox';
+import { Panel, Box, Table as MBTable } from '@sparkpost/matchbox';
 
 type TableProps = {
   children?: React.ReactNode;
@@ -7,11 +7,13 @@ type TableProps = {
 const Table = (props: TableProps): JSX.Element => {
   const { children } = props;
   return (
-    <Panel>
-      <MBTable p="500">
-        {children}
-      </MBTable>
-    </Panel>
+    <Box mb="550" px="400">
+      <Panel>
+        <MBTable p="500">
+          {children}
+        </MBTable>
+      </Panel>
+    </Box>
   )
 }
 

--- a/components/markdown/table.tsx
+++ b/components/markdown/table.tsx
@@ -7,7 +7,7 @@ type TableProps = {
 const Table = (props: TableProps): JSX.Element => {
   const { children } = props;
   return (
-    <Box mb="550" px="400">
+    <Box mb="550" px="500">
       <Panel>
         <MBTable p="500">
           {children}


### PR DESCRIPTION
## What changed
- Adds margin bottom and horizontal padding to Table markdown component

## How to verify
- Visit a route with a table locally or at the deploy preview (e.g. http://localhost:3000/momentum/4/modules/summary-all-modules)