### PR TITLE
WE-342 Generate links from headings

### DIFF
--- a/components/markdown/heading.tsx
+++ b/components/markdown/heading.tsx
@@ -1,12 +1,36 @@
 import React from 'react';
 import { Box, BoxProps } from '@sparkpost/matchbox';
+import { tokens } from '@sparkpost/design-tokens';
 import * as Polymorphic from 'utils/types';
+import { slugify } from 'utils/string';
 import Container from './container';
+import css from '@styled-system/css';
 import styled from 'styled-components';
 
 const StyledHeading = styled(Box)<BoxProps>`
   div:first-child > & {
     padding-top: 0;
+  }
+`;
+
+const StyledAnchorLink = styled.a<{ $hovered?: boolean }>`
+  display: inline-block;
+  text-decoration: none;
+  transition: ${tokens.motionDuration_fast};
+
+  &,
+  &:visited {
+    ${({ $hovered }) =>
+      css({
+        color: 'gray.700',
+        pl: '200',
+        opacity: $hovered ? '1' : '0',
+      })}
+  }
+  &:hover {
+    ${css({
+      color: 'blue.700',
+    })}
   }
 `;
 
@@ -67,21 +91,33 @@ export const getPaddingTop = (as?: As): string => {
 
 const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(function Heading(props, ref) {
   const { children, as } = props;
+  const [hovered, setHovered] = React.useState<boolean>(false);
+
+  const childrenAsString = React.Children.toArray(children)
+    .filter((child) => typeof child === 'string')
+    .join('-');
+  const slugified = slugify(childrenAsString);
 
   return (
     <Container>
-      <StyledHeading
-        as={as}
-        fontSize={getFontSize(as)}
-        lineHeight={getFontSize(as)}
-        mb={getMarginBottom(as)}
-        pt={getPaddingTop(as)}
-        fontWeight="medium"
-        ref={ref}
-        color="gray.1000"
-      >
-        {children}
-      </StyledHeading>
+      <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
+        <StyledHeading
+          as={as}
+          id={slugified}
+          fontSize={getFontSize(as)}
+          lineHeight={getFontSize(as)}
+          mb={getMarginBottom(as)}
+          pt={getPaddingTop(as)}
+          fontWeight="medium"
+          ref={ref}
+          color="gray.1000"
+        >
+          {children}
+          <StyledAnchorLink href={`#${slugified}`} aria-hidden="true" $hovered={hovered}>
+            #
+          </StyledAnchorLink>
+        </StyledHeading>
+      </div>
     </Container>
   );
 }) as Polymorphic.ForwardRefComponent<'div', BoxProps>;

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -1,0 +1,21 @@
+/**
+ * Slugifies a string
+ */
+export const slugify = (str: string): string => {
+  str = str.replace(/^\s+|\s+$/g, ''); // trim
+  str = str.toLowerCase();
+
+  // remove accents, swap ñ for n, etc
+  const from = 'àáäâèéëêìíïîòóöôùúüûñç·/_,:;';
+  const to = 'aaaaeeeeiiiioooouuuunc------';
+  for (let i = 0, l = from.length; i < l; i++) {
+    str = str.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
+  }
+
+  str = str
+    .replace(/[^a-z0-9 -]/g, '') // remove invalid chars
+    .replace(/\s+/g, '-') // collapse whitespace and replace by -
+    .replace(/-+/g, '-'); // collapse dashes
+
+  return str;
+};


### PR DESCRIPTION
**What Changed**
- Headings now generate anchor links 

**How to Verify**
- Go to a markdown page with headings, eg http://localhost:3000/momentum/4/loam#engagement-tracking
- Verify the headings have links rendered and ids are slugified properly