### PR TITLE
WE-343 Add segment page tracking on url change

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { ThemeProvider } from '@sparkpost/matchbox';
 import * as gtag from '../utils/gtm';
+import { page as segmentPage } from 'utils/segment';
 import * as Sentry from '@sentry/react';
 import { Integrations } from '@sentry/tracing';
 import CookieConsent from 'components/site/cookieConsent';
@@ -43,6 +44,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
   useEffect(() => {
     const handleRouteChange = (url: URL) => {
       gtag.pageview(url);
+      segmentPage();
     };
     router.events.on('routeChangeComplete', handleRouteChange);
     return () => {

--- a/utils/segment.ts
+++ b/utils/segment.ts
@@ -3,15 +3,23 @@ import { getWindow } from 'utils/ssr';
 declare global {
   interface Window {
     analytics: {
-      track: (event: string, properties: {[key: string]: string | boolean }) => void;
-    }
+      track: (event: string, properties: { [key: string]: string | boolean }) => void;
+      page: (category?: string, name?: string) => void;
+    };
   }
 }
 
 // Segment track
-export const track = (event: string, properties: {[key: string]: string | boolean}) => {
+export const track = (event: string, properties: { [key: string]: string | boolean }) => {
   const environment = getWindow();
   if (environment && environment.analytics) {
     environment.analytics.track(event, properties);
+  }
+};
+
+export const page = (category?: string, name?: string) => {
+  const environment = getWindow();
+  if (environment && environment.analytics) {
+    environment.analytics.page(category, name);
   }
 };


### PR DESCRIPTION
**What Changed**
- Adds segment page tracking call to the routing effect in `_app.tsx`

**How to verify**
- Visit the deploy preview and log into Segment's debugger
- Try to navigate using the sidebar