### PR TITLE
WE-322 Add side nav

### DIFF
--- a/components/site/docsLayout.tsx
+++ b/components/site/docsLayout.tsx
@@ -1,13 +1,22 @@
 import Layout from './layout';
-import DocsNavigation from './docsNavigation';
+import Navigation, { NavigationItemProps } from './navigation';
 
 type LayoutProps = {
   children?: React.ReactNode;
+  navigationData?: NavigationItemProps[];
 };
 
 const DocsLayout = (props: LayoutProps): JSX.Element => {
-  const { children } = props;
-  return <Layout navigationComponent={<DocsNavigation />}>{children}</Layout>;
+  const { children, navigationData } = props;
+  return (
+    <Layout
+      navigationComponent={
+        <Navigation data={navigationData} title="Documentation" titleLink="/docs" />
+      }
+    >
+      {children}
+    </Layout>
+  );
 };
 
 export default DocsLayout;

--- a/components/site/docsNavigation.tsx
+++ b/components/site/docsNavigation.tsx
@@ -1,5 +1,0 @@
-const DocsNavigation = () => {
-  return <div>Nav goes here</div>;
-};
-
-export default DocsNavigation;

--- a/components/site/momentumLayout.tsx
+++ b/components/site/momentumLayout.tsx
@@ -1,5 +1,6 @@
-import MomentumNavigation from 'components/site/momentumNavigation';
+import Navigation from 'components/site/navigation';
 import Layout from './layout';
+import data from 'content/momentum/navigation.yml';
 
 type LayoutProps = {
   children?: React.ReactNode;
@@ -7,7 +8,15 @@ type LayoutProps = {
 
 const MomentumLayout = (props: LayoutProps): JSX.Element => {
   const { children } = props;
-  return <Layout navigationComponent={<MomentumNavigation />}>{children}</Layout>;
+  return (
+    <Layout
+      navigationComponent={
+        <Navigation data={data} title="Momentum Documentation" titleLink="/momentum" />
+      }
+    >
+      {children}
+    </Layout>
+  );
 };
 
 export default MomentumLayout;

--- a/components/site/navigation.tsx
+++ b/components/site/navigation.tsx
@@ -14,14 +14,19 @@ import styled from 'styled-components';
 import css from '@styled-system/css';
 import { tokens } from '@sparkpost/design-tokens';
 import useStatus from 'hooks/useStatus';
-import data from 'content/momentum/navigation.yml';
 
-export interface MomentumNavigationItemProps {
+export interface NavigationItemProps {
   title: string;
   link: string;
   items?: this[];
   level?: number;
 }
+
+type NavigationProps = {
+  data?: NavigationItemProps[];
+  title: string;
+  titleLink: string;
+};
 
 const StyledLink = styled.a<{ $active?: boolean; $level?: number }>`
   display: block;
@@ -59,14 +64,14 @@ const StatusColorMap = {
   critical: 'red.700',
 };
 
-const MomentumNavigation = (): JSX.Element | null => {
+const Navigation = (props: NavigationProps): JSX.Element | null => {
+  const { data = [], title, titleLink } = props;
   const { status } = useStatus();
-  const environment = getWindow();
 
   return (
     <Box width={['100%', null, '260px']} position="sticky" top="0">
-      <Link href="/momentum" passHref>
-        <StyledLink $active={environment?.location?.pathname === '/momentum'}>
+      <Link href={titleLink} passHref>
+        <StyledLink>
           <Box
             display={['none', null, 'inline-block']}
             fontSize="200"
@@ -74,7 +79,7 @@ const MomentumNavigation = (): JSX.Element | null => {
             fontWeight="semibold"
             pl="500"
           >
-            Momentum Documentation
+            {title}
           </Box>
         </StyledLink>
       </Link>
@@ -164,9 +169,9 @@ const getActiveUrl = (location: any) => {
 };
 
 const findActiveChild = (
-  items: MomentumNavigationItemProps[],
+  items: NavigationItemProps[],
   activeUrl: string,
-): MomentumNavigationItemProps | undefined => {
+): NavigationItemProps | undefined => {
   return items.find((item) => {
     const hasDirectChild = item.link == activeUrl;
 
@@ -200,7 +205,7 @@ const StyledChevronWrapper = styled(Box)<BoxProps & { $active?: boolean }>`
   }}
 `;
 
-const Item = (props: MomentumNavigationItemProps): JSX.Element => {
+const Item = (props: NavigationItemProps): JSX.Element => {
   const { link, title, items, level = 0 } = props;
   const [active, setActive] = React.useState<boolean>(false);
   const [expanded, setExpanded] = React.useState<boolean>(false);
@@ -249,4 +254,4 @@ const Item = (props: MomentumNavigationItemProps): JSX.Element => {
   );
 };
 
-export default MomentumNavigation;
+export default Navigation;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -79,7 +79,7 @@ export const getSupportNavigation = () => {
 
   // Then populate category items
   const navigationData = categoryData.map((category) => {
-    const postsInCategory = glob.sync(`content${category.link}/*.md`);
+    const postsInCategory = glob.sync(`content${category.link}/!(index).md`);
     return {
       ...category,
       items: postsInCategory.map((file) => {

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -1,9 +1,15 @@
 import { GetStaticProps, GetStaticPaths } from 'next';
-import { getAllCategoryPostPaths, getSingleCategoryPost, categoryPath } from 'lib/api';
+import {
+  getSupportNavigation,
+  getAllCategoryPostPaths,
+  getSingleCategoryPost,
+  categoryPath,
+} from 'lib/api';
 import SEO from 'components/site/seo';
 import Markdown from 'components/markdown';
 import DocsLayout from 'components/site/docsLayout';
 import DocumentationContent from 'components/site/documentationContent';
+import type { NavigationItemProps } from 'components/site/navigation';
 
 type PostPageProps = {
   content: string;
@@ -12,14 +18,15 @@ type PostPageProps = {
     description?: string;
     lastUpdated?: string;
   };
+  navigationData?: NavigationItemProps[];
 };
 
 const PostPage = (props: PostPageProps): JSX.Element => {
-  const { content, data } = props;
+  const { content, data, navigationData } = props;
   return (
     <>
       <SEO title={data.title} description={data.description} />
-      <DocsLayout>
+      <DocsLayout navigationData={navigationData}>
         <DocumentationContent title={data.title} lastUpdated={data.lastUpdated}>
           <Markdown>{content}</Markdown>
         </DocumentationContent>
@@ -33,7 +40,8 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     return { props: {} };
   }
   const { content, data } = getSingleCategoryPost(params.slug, categoryPath('docs')) || {};
-  return { props: { content, data } };
+  const navigationData = getSupportNavigation() || [];
+  return { props: { content, data, navigationData } };
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -1,18 +1,31 @@
+import { GetStaticProps } from 'next';
 import SEO from 'components/site/seo';
 import DocsLayout from 'components/site/docsLayout';
+import { getSupportNavigation } from 'lib/api';
+import type { NavigationItemProps } from 'components/site/navigation';
 
-const IndexPage = (): JSX.Element => {
+type IndexPageProps = {
+  navigationData?: NavigationItemProps[];
+};
+
+const IndexPage = (props: IndexPageProps): JSX.Element => {
+  const { navigationData } = props;
   return (
     <>
       <SEO
         title="Support Documentation - SparkPost"
         description="SparkPost Support Documentation"
       />
-      <DocsLayout>
+      <DocsLayout navigationData={navigationData}>
         <div>There's nothing here yet</div>
       </DocsLayout>
     </>
   );
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+  const navigationData = getSupportNavigation() || [];
+  return { props: { navigationData } };
 };
 
 export default IndexPage;


### PR DESCRIPTION
**What Changed**
- Creates a function to read the `content/docs` directory to generate navigation items
- Abstracts `MomentumNavigation` component into `Navigation`

**How to verify**
- Visit a support docs page, eg `/docs`
- Verify the side navigation works
- Verify momentum navigation works as well to verify the component abstraction