### PR TITLE
WE-348: Adds the support docs nav to the submit a ticket page

### DIFF
--- a/components/site/feedback.tsx
+++ b/components/site/feedback.tsx
@@ -8,77 +8,77 @@ import { track } from 'utils/segment';
 const reasonList = [
   {
     label: "Didn't answer my question.",
-    value: 'didnt-answer-question'
+    value: 'didnt-answer-question',
   },
   {
-    label: "Hard to understand.",
-    value: 'hard-to-understand'
+    label: 'Hard to understand.',
+    value: 'hard-to-understand',
   },
   {
-    label: "Missing the information I need.",
-    value: 'missing-information'
+    label: 'Missing the information I need.',
+    value: 'missing-information',
   },
   {
-    label: "Incorrect information.",
-    value: 'incorrect-information'
+    label: 'Incorrect information.',
+    value: 'incorrect-information',
   },
   {
-    label: "Other.",
-    value: 'other'
-  }
-]
+    label: 'Other.',
+    value: 'other',
+  },
+];
 
 type ReasonType = {
   label: string;
   value: string;
-}
+};
 
 const Feedback = (): JSX.Element => {
   const { getActivatorProps, getModalProps } = useModal();
   const [reason, setReason] = useState<ReasonType>();
-  const [loadingPositive, setLoadingPositive] = useState<boolean>(false);
-  const [loadingNegative, setLoadingNegative] = useState<boolean>(false);
+  const [loadingPositive, setLoadingPositive] = useState<boolean | undefined>(undefined);
+  const [loadingNegative, setLoadingNegative] = useState<boolean | undefined>(undefined);
   const { dispatch } = useContext(AlertsContext);
   const { asPath } = useRouter();
   const { onClose } = getModalProps();
 
   const handleChange = (reason: ReasonType) => {
-    setReason(reason)
-  }
+    setReason(reason);
+  };
 
   const handleTextChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const text = event.target.value;
     setReason({
       label: text,
-      value: 'other'
-    })
-  }
+      value: 'other',
+    });
+  };
 
   const createAlert = () => {
     // Adds delay to make the interaction seem less artificial
     setTimeout(() => {
-      setLoadingPositive(false);
-      setLoadingNegative(false);
+      setLoadingPositive(undefined);
+      setLoadingNegative(undefined);
       dispatch({
         type: 'addAlert',
         alert: {
           id: uuid(),
           title: 'Feedback submitted',
-          status: 'success'
-        }
-      })
-    }, 500)
-  }
+          status: 'success',
+        },
+      });
+    }, 500);
+  };
 
   const submitPositiveFeedback = () => {
     setLoadingPositive(true);
     track('User Feedback', {
       url: asPath,
       docs: asPath.includes('momentum') ? 'momentum' : 'support',
-      helpful: true
+      helpful: true,
     });
     createAlert();
-  }
+  };
 
   const submitNegativeFeedback = () => {
     setLoadingNegative(true);
@@ -86,26 +86,36 @@ const Feedback = (): JSX.Element => {
       url: asPath,
       docs: asPath.includes('momentum') ? 'momentum' : 'support',
       helpful: false,
-      reason: reason?.label || ''
-    })
+      reason: reason?.label || '',
+    });
     onClose();
     createAlert();
-  }
+  };
 
   return (
     <Box px="500">
-      <Box fontSize="500" lineHeight="500" fontWeight="semibold">Was this page helpful?</Box>
+      <Box fontSize="500" lineHeight="500" fontWeight="semibold">
+        Was this page helpful?
+      </Box>
       <Box display="flex" mt="400">
-        <Button variant="outline" loading={loadingPositive} color="blue" mr="300" onClick={submitPositiveFeedback}>Yes</Button>
-        <Button variant="outline" color="blue" {...getActivatorProps()}>No</Button>
+        <Button
+          variant="outline"
+          loading={loadingPositive}
+          color="blue"
+          mr="300"
+          onClick={submitPositiveFeedback}
+        >
+          Yes
+        </Button>
+        <Button variant="outline" color="blue" {...getActivatorProps()}>
+          No
+        </Button>
       </Box>
       <Modal {...getModalProps()} maxWidth="1150">
-        <Modal.Header showCloseButton>
-          What is the reason for your feedback?
-        </Modal.Header>
+        <Modal.Header showCloseButton>What is the reason for your feedback?</Modal.Header>
         <Modal.Content>
           <Radio.Group label="Choose a reason" labelHidden>
-            {reasonList.map(reason => {
+            {reasonList.map((reason) => {
               return (
                 <Radio
                   key={reason.value}
@@ -115,25 +125,27 @@ const Feedback = (): JSX.Element => {
                   name="reason"
                   onChange={() => handleChange(reason)}
                 />
-              )
+              );
             })}
           </Radio.Group>
-          {reason?.value === "other" && 
-            <TextField 
-              mt="300" 
-              id="other" 
-              multiline 
+          {reason?.value === 'other' && (
+            <TextField
+              mt="300"
+              id="other"
+              multiline
               placeholder="Please share specific details about your feedback."
               onChange={handleTextChange}
             />
-          }
+          )}
         </Modal.Content>
         <Modal.Footer>
-          <Button color="blue" loading={loadingNegative} onClick={submitNegativeFeedback}>Submit</Button>
+          <Button color="blue" loading={loadingNegative} onClick={submitNegativeFeedback}>
+            Submit
+          </Button>
         </Modal.Footer>
       </Modal>
     </Box>
-  )
-}
+  );
+};
 
 export default Feedback;

--- a/pages/submit-a-ticket.tsx
+++ b/pages/submit-a-ticket.tsx
@@ -1,13 +1,20 @@
+import { GetStaticProps } from 'next';
 import type { NextPage } from 'next';
+import { getSupportNavigation } from 'lib/api';
 import { Box, Text, Button, Stack } from '@sparkpost/matchbox';
 import SEO from 'components/site/seo';
 import DocsLayout from 'components/site/docsLayout';
+import type { NavigationItemProps } from 'components/site/navigation';
 
-const SubmitATicketPage: NextPage = () => {
+type SubmitATicketPageProps = {
+  navigationData?: NavigationItemProps[];
+};
+
+const SubmitATicketPage: NextPage<SubmitATicketPageProps> = ({ navigationData }) => {
   return (
     <>
       <SEO title="Submit A Ticket" />
-      <DocsLayout>
+      <DocsLayout navigationData={navigationData}>
         <Box px="400" maxWidth="1150">
           <Stack>
             <Text as="h1" looksLike="h2">
@@ -42,6 +49,11 @@ const SubmitATicketPage: NextPage = () => {
       </DocsLayout>
     </>
   );
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+  const navigationData = getSupportNavigation() || [];
+  return { props: { navigationData } };
 };
 
 export default SubmitATicketPage;


### PR DESCRIPTION
### What changed
Adds the support docs nav to the submit a ticket page. Also, fixes a type error I was experiencing when building.

### How to verify
- navigate to `localhost:3000/submit-a-ticket`
- verify the support docs navigation shows up