### PR TITLE
WE-345 Make breadcrumbs and search categories friendly

### DIFF
--- a/components/site/algolia/results.tsx
+++ b/components/site/algolia/results.tsx
@@ -1,9 +1,12 @@
+import React from 'react';
+import { CategoriesContext } from 'context/categories';
 import { Box, Inline, Stack } from '@sparkpost/matchbox';
 import { ChevronRight } from '@sparkpost/matchbox-icons';
 import { connectStateResults, Highlight, Hits } from 'react-instantsearch-dom';
 import Link from 'next/link';
 import css from '@styled-system/css';
 import styled from 'styled-components';
+import { toTitleCase } from 'utils/string';
 
 const ResultsWrapper = styled.div`
   .ais-Hits-item {
@@ -68,6 +71,7 @@ const Result = ({ hit }: ResultProps) => {
   const parts = hit.slug.split('/');
   const crumbLength = parts.length - 1;
   const crumbs = parts.slice(1, crumbLength);
+  const categories = React.useContext(CategoriesContext);
 
   return (
     <Link href={hit.slug} passHref>
@@ -79,9 +83,11 @@ const Result = ({ hit }: ResultProps) => {
               <Inline space="100">
                 In
                 {crumbs.map((crumb, i) => {
+                  const category = categories.find(({ key }) => key === crumb);
+                  const label = category?.label || toTitleCase(crumb);
                   return (
                     <span key={i}>
-                      {crumb} {i !== crumbs.length - 1 ? <ChevronRight size={16} /> : null}
+                      {label} {i !== crumbs.length - 1 ? <ChevronRight size={16} /> : null}
                     </span>
                   );
                 })}

--- a/components/site/breadcrumbs.tsx
+++ b/components/site/breadcrumbs.tsx
@@ -1,44 +1,48 @@
+import React from 'react';
+import { CategoriesContext } from 'context/categories';
 import { useRouter } from 'next/router';
 import { Breadcrumb } from '@sparkpost/matchbox';
+import { toTitleCase } from 'utils/string';
 
 type BreadcrumbProps = {
   title?: string;
-}
-
-const urlMap: {[key: string]: string} = {
-  'momentum': 'Momentum Documentation',
-  '4': 'Momentum 4.x',
-  '3': 'Momentum 3.x',
-  'mobile': 'Momentum Mobile',
-  'changelog': 'Changelog'
-}
+};
 
 const Breadcrumbs = ({ title }: BreadcrumbProps): JSX.Element => {
   const router = useRouter();
   const path = router.asPath;
-  const pathAsArray = path.split('/').filter(i => i)
+  const pathAsArray = path.split('/').filter((i) => i);
+
+  const categories = React.useContext(CategoriesContext);
 
   const getPrettyName = (link: string, index: number) => {
-    if((index + 1) == pathAsArray.length) {
-      return title
+    if (index + 1 == pathAsArray.length) {
+      return title;
     }
 
-    return urlMap[link] || link
-  }
+    const category = categories.find(({ key }) => key === link);
+    return category?.label || toTitleCase(link);
+  };
 
   const getLink = (link: string, index: number) => {
     return pathAsArray.slice(0, index + 1).join('/');
-  }
+  };
 
   return (
     <Breadcrumb mb="500">
       {pathAsArray.map((link, index) => {
         return (
-          <Breadcrumb.Link key={link} active={(index + 1) === pathAsArray.length} to={`/${getLink(link, index)}`}>{getPrettyName(link, index)}</Breadcrumb.Link>
-        )
+          <Breadcrumb.Link
+            key={link}
+            active={index + 1 === pathAsArray.length}
+            to={`/${getLink(link, index)}`}
+          >
+            {getPrettyName(link, index)}
+          </Breadcrumb.Link>
+        );
       })}
     </Breadcrumb>
-  )
-}
+  );
+};
 
 export default Breadcrumbs;

--- a/context/categories.tsx
+++ b/context/categories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export type Category = {
+  label?: string;
+  key?: string;
+};
+
+type CategoriesProviderProps = {
+  children?: React.ReactNode;
+  data?: Category[];
+};
+
+export const CategoriesContext = React.createContext<Category[]>([]);
+
+export const CategoriesProvider = (props: CategoriesProviderProps): JSX.Element => {
+  const { children, data = [] } = props;
+
+  return <CategoriesContext.Provider value={data}>{children}</CategoriesContext.Provider>;
+};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -96,7 +96,7 @@ export const getSupportNavigation = () => {
 /**
  * Retrieves category information for breadcrumb friendly labels
  */
-export const getCategorData = (category: CategoryOption) => {
+export const getCategoryData = (category: CategoryOption) => {
   const contentPath = `content/${category}`;
   const indexFilePaths = glob.sync(`${contentPath}/**/index.md`);
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -92,3 +92,22 @@ export const getSupportNavigation = () => {
 
   return navigationData;
 };
+
+/**
+ * Retrieves category information for breadcrumb friendly labels
+ */
+export const getCategorData = (category: CategoryOption) => {
+  const contentPath = `content/${category}`;
+  const indexFilePaths = glob.sync(`${contentPath}/**/index.md`);
+
+  const categoryData = indexFilePaths.map((file) => {
+    const { data } = readFile(file);
+    const parts = file.split('/');
+    return {
+      label: data.name || data.title,
+      key: parts[parts.length - 2],
+    };
+  });
+
+  return categoryData;
+};

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -1,6 +1,6 @@
 import { GetStaticProps, GetStaticPaths } from 'next';
 import {
-  getCategorData,
+  getCategoryData,
   getSupportNavigation,
   getAllCategoryPostPaths,
   getSingleCategoryPost,
@@ -44,7 +44,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   }
   const { content, data } = getSingleCategoryPost(params.slug, categoryPath('docs')) || {};
   const navigationData = getSupportNavigation() || [];
-  const categoryData = getCategorData('docs');
+  const categoryData = getCategoryData('docs');
   return { props: { content, data, navigationData, categoryData } };
 };
 

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -1,10 +1,12 @@
 import { GetStaticProps, GetStaticPaths } from 'next';
 import {
+  getCategorData,
   getSupportNavigation,
   getAllCategoryPostPaths,
   getSingleCategoryPost,
   categoryPath,
 } from 'lib/api';
+import { CategoriesProvider, Category } from 'context/categories';
 import SEO from 'components/site/seo';
 import Markdown from 'components/markdown';
 import DocsLayout from 'components/site/docsLayout';
@@ -19,19 +21,20 @@ type PostPageProps = {
     lastUpdated?: string;
   };
   navigationData?: NavigationItemProps[];
+  categoryData: Category[];
 };
 
 const PostPage = (props: PostPageProps): JSX.Element => {
-  const { content, data, navigationData } = props;
+  const { content, data, navigationData, categoryData } = props;
   return (
-    <>
+    <CategoriesProvider data={categoryData}>
       <SEO title={data.title} description={data.description} />
       <DocsLayout navigationData={navigationData}>
         <DocumentationContent title={data.title} lastUpdated={data.lastUpdated}>
           <Markdown>{content}</Markdown>
         </DocumentationContent>
       </DocsLayout>
-    </>
+    </CategoriesProvider>
   );
 };
 
@@ -41,7 +44,8 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   }
   const { content, data } = getSingleCategoryPost(params.slug, categoryPath('docs')) || {};
   const navigationData = getSupportNavigation() || [];
-  return { props: { content, data, navigationData } };
+  const categoryData = getCategorData('docs');
+  return { props: { content, data, navigationData, categoryData } };
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -1,17 +1,20 @@
 import { GetStaticProps } from 'next';
+import { getCategorData } from 'lib/api';
 import SEO from 'components/site/seo';
 import DocsLayout from 'components/site/docsLayout';
 import { getSupportNavigation } from 'lib/api';
 import type { NavigationItemProps } from 'components/site/navigation';
+import { CategoriesProvider, Category } from 'context/categories';
 
 type IndexPageProps = {
   navigationData?: NavigationItemProps[];
+  categoryData: Category[];
 };
 
 const IndexPage = (props: IndexPageProps): JSX.Element => {
-  const { navigationData } = props;
+  const { categoryData, navigationData } = props;
   return (
-    <>
+    <CategoriesProvider data={categoryData}>
       <SEO
         title="Support Documentation - SparkPost"
         description="SparkPost Support Documentation"
@@ -19,13 +22,14 @@ const IndexPage = (props: IndexPageProps): JSX.Element => {
       <DocsLayout navigationData={navigationData}>
         <div>There's nothing here yet</div>
       </DocsLayout>
-    </>
+    </CategoriesProvider>
   );
 };
 
 export const getStaticProps: GetStaticProps = async () => {
   const navigationData = getSupportNavigation() || [];
-  return { props: { navigationData } };
+  const categoryData = getCategorData('docs');
+  return { props: { navigationData, categoryData } };
 };
 
 export default IndexPage;

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -1,5 +1,5 @@
 import { GetStaticProps } from 'next';
-import { getCategorData } from 'lib/api';
+import { getCategoryData } from 'lib/api';
 import SEO from 'components/site/seo';
 import DocsLayout from 'components/site/docsLayout';
 import { getSupportNavigation } from 'lib/api';
@@ -28,7 +28,7 @@ const IndexPage = (props: IndexPageProps): JSX.Element => {
 
 export const getStaticProps: GetStaticProps = async () => {
   const navigationData = getSupportNavigation() || [];
-  const categoryData = getCategorData('docs');
+  const categoryData = getCategoryData('docs');
   return { props: { navigationData, categoryData } };
 };
 

--- a/pages/momentum/[...slug].tsx
+++ b/pages/momentum/[...slug].tsx
@@ -1,6 +1,6 @@
 import { GetStaticProps, GetStaticPaths } from 'next';
 import {
-  getCategorData,
+  getCategoryData,
   getAllCategoryPostPaths,
   getSingleCategoryPost,
   categoryPath,
@@ -41,7 +41,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     return { props: {} };
   }
   const { content, data } = getSingleCategoryPost(params.slug, categoryPath('momentum')) || {};
-  const categoryData = getCategorData('momentum');
+  const categoryData = getCategoryData('momentum');
   return { props: { content, data, categoryData } };
 };
 

--- a/pages/momentum/[...slug].tsx
+++ b/pages/momentum/[...slug].tsx
@@ -1,5 +1,11 @@
 import { GetStaticProps, GetStaticPaths } from 'next';
-import { getAllCategoryPostPaths, getSingleCategoryPost, categoryPath } from 'lib/api';
+import {
+  getCategorData,
+  getAllCategoryPostPaths,
+  getSingleCategoryPost,
+  categoryPath,
+} from 'lib/api';
+import { CategoriesProvider, Category } from 'context/categories';
 import MomentumLayout from 'components/site/momentumLayout';
 import DocumentationContent from 'components/site/documentationContent';
 import SEO from 'components/site/seo';
@@ -12,20 +18,21 @@ type PostPageProps = {
     description?: string;
     lastUpdated?: string;
   };
+  categoryData: Category[];
 };
 
 const PostPage = (props: PostPageProps): JSX.Element => {
-  const { content, data } = props;
+  const { content, data, categoryData } = props;
 
   return (
-    <>
+    <CategoriesProvider data={categoryData}>
       <SEO title={data.title} description={data.description} />
       <MomentumLayout>
         <DocumentationContent title={data.title} lastUpdated={data.lastUpdated}>
           <Markdown>{content}</Markdown>
         </DocumentationContent>
       </MomentumLayout>
-    </>
+    </CategoriesProvider>
   );
 };
 
@@ -34,7 +41,8 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     return { props: {} };
   }
   const { content, data } = getSingleCategoryPost(params.slug, categoryPath('momentum')) || {};
-  return { props: { content, data } };
+  const categoryData = getCategorData('momentum');
+  return { props: { content, data, categoryData } };
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {

--- a/pages/momentum/index.tsx
+++ b/pages/momentum/index.tsx
@@ -1,10 +1,18 @@
+import { GetStaticProps } from 'next';
+import { getCategorData } from 'lib/api';
 import MomentumHomePageContent from 'components/site/momentumHomePageContent';
 import SEO from 'components/site/seo';
 import MomentumLayout from 'components/site/momentumLayout';
+import { CategoriesProvider, Category } from 'context/categories';
 
-const IndexPage = (): JSX.Element => {
+type IndexPageProps = {
+  categoryData: Category[];
+};
+
+const IndexPage = (props: IndexPageProps): JSX.Element => {
+  const { categoryData } = props;
   return (
-    <>
+    <CategoriesProvider data={categoryData}>
       <SEO
         title="Momentum Documentation - SparkPost"
         description="SparkPost Momentum Documentation"
@@ -12,8 +20,13 @@ const IndexPage = (): JSX.Element => {
       <MomentumLayout>
         <MomentumHomePageContent />
       </MomentumLayout>
-    </>
+    </CategoriesProvider>
   );
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+  const categoryData = getCategorData('momentum');
+  return { props: { categoryData } };
 };
 
 export default IndexPage;

--- a/pages/momentum/index.tsx
+++ b/pages/momentum/index.tsx
@@ -1,5 +1,5 @@
 import { GetStaticProps } from 'next';
-import { getCategorData } from 'lib/api';
+import { getCategoryData } from 'lib/api';
 import MomentumHomePageContent from 'components/site/momentumHomePageContent';
 import SEO from 'components/site/seo';
 import MomentumLayout from 'components/site/momentumLayout';
@@ -25,7 +25,7 @@ const IndexPage = (props: IndexPageProps): JSX.Element => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-  const categoryData = getCategorData('momentum');
+  const categoryData = getCategoryData('momentum');
   return { props: { categoryData } };
 };
 

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -19,3 +19,9 @@ export const slugify = (str: string): string => {
 
   return str;
 };
+
+export const toTitleCase = (str: string): string => {
+  return str.replace(/\w\S*/g, function (txt) {
+    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  });
+};


### PR DESCRIPTION
**What Changed**
- Adds a new `api` function to pull down categories from `index.md` files
- Adds new React context to hold this data and pulls it into relevant components

**How to verfiy**
- Visit the deploy preview or run the site locally
- Verify categories are friendly inside the algolia search for both docs and momentum
- Verify breadcrumbs are friendly for both docs and momentum