### PR TITLE
WE-365 Close Algolia search on click inside menu

### DIFF
--- a/components/site/algolia/results.tsx
+++ b/components/site/algolia/results.tsx
@@ -107,7 +107,10 @@ type SearchResultsProps = {
   show?: boolean;
 };
 
-const SearchResults = (props: SearchResultsProps): JSX.Element | null => {
+const SearchResults = React.forwardRef<HTMLDivElement, SearchResultsProps>(function SearchResults(
+  props,
+  ref,
+) {
   const { show } = props;
 
   if (!show) {
@@ -115,7 +118,7 @@ const SearchResults = (props: SearchResultsProps): JSX.Element | null => {
   }
 
   return (
-    <Box>
+    <Box ref={ref}>
       <Box
         position="absolute"
         width="100%"
@@ -136,6 +139,6 @@ const SearchResults = (props: SearchResultsProps): JSX.Element | null => {
       </Box>
     </Box>
   );
-};
+});
 
 export default SearchResults;

--- a/components/site/algolia/search.tsx
+++ b/components/site/algolia/search.tsx
@@ -17,11 +17,13 @@ const Search = (props: SearchProps): JSX.Element => {
   const [query, setQuery] = React.useState('');
   const [hasFocus, setHasFocus] = React.useState(false);
   const container = React.useRef<HTMLDivElement>(null);
+  const menu = React.useRef<HTMLDivElement>(null);
 
   useWindowEvent('click', function (e) {
     const isInside = container && container.current?.contains(e.target as Node);
+    const isInsideMenu = menu && menu.current?.contains(e.target as Node);
 
-    if (hasFocus && !isInside) {
+    if ((hasFocus && !isInside) || isInsideMenu) {
       setHasFocus(false);
     }
   });
@@ -34,7 +36,7 @@ const Search = (props: SearchProps): JSX.Element => {
         onSearchStateChange={({ query }) => setQuery(query)}
       >
         <SearchBox onFocus={() => setHasFocus(true)} hasFocus={hasFocus} />
-        <SearchResults show={query.length > 0 && hasFocus} />
+        <SearchResults ref={menu} show={query.length > 0 && hasFocus} />
       </InstantSearch>
     </Box>
   );


### PR DESCRIPTION
**What Changed**
- Adds a check for inside-menu clicks in side the window even handler for the search menu

**How to test**
- Try clicking or selecting an item in the Algolia search menu
- Verify the menu closes on item selection