### PR TITLE
WE-371: 600px description width

### DIFF
--- a/components/site/docsIndexListPageContent.tsx
+++ b/components/site/docsIndexListPageContent.tsx
@@ -26,7 +26,11 @@ const DocsIndexListPageContent = (props: DocsIndexListPageContentProps) => {
                     <Tag>{formatDate(item.lastUpdated)}</Tag>
                   </Box>
                 )}
-                {item.description && <Box as="p">{item.description}</Box>}
+                {item.description && (
+                  <Box as="p" maxWidth="1150">
+                    {item.description}
+                  </Box>
+                )}
                 <Box pt="400">
                   <Link href={item.link} passHref>
                     <Button variant="outline" color="blue">

--- a/components/site/documentationContent.tsx
+++ b/components/site/documentationContent.tsx
@@ -26,18 +26,15 @@ const DocumentationContent = ({
         <Box as="h1" fontSize="600" lineHeight="600" fontWeight="semibold">
           {title}
         </Box>
-        {description ||
-          (lastUpdated && (
-            <Box fontSize="200" lineHeight="200" pt="200">
-              {lastUpdated && !isIndex ? (
-                <>
-                  Last updated <Tag ml="300">{formatDate(lastUpdated)}</Tag>
-                </>
-              ) : (
-                description
-              )}
-            </Box>
-          ))}
+        <Box fontSize="200" lineHeight="200" pt="200" maxWidth="1150">
+          {lastUpdated && !isIndex ? (
+            <>
+              Last updated <Tag ml="300">{formatDate(lastUpdated)}</Tag>
+            </>
+          ) : (
+            description
+          )}
+        </Box>
       </Box>
       <Box as="hr" my="500" />
       <Box px="0">{children}</Box>

--- a/components/site/layoutWrap.tsx
+++ b/components/site/layoutWrap.tsx
@@ -9,9 +9,6 @@ type LayoutWrapProps = {
 
 const LayoutWrap = (props: LayoutWrapProps): JSX.Element => {
   const { children, bg } = props;
-  // const { getDrawerProps, getActivatorProps } = useDrawer();
-  // const { route } = useRouter();
-  // const category = route.split('/')[1];
 
   return (
     <Box display="flex" flexDirection="column" minHeight="100vh" bg={bg ? bg : 'gray.100'}>


### PR DESCRIPTION
### What Changed
The description areas in the index list and header of a page now have a maxWidth applied.

### How to verify
- navigate to http://localhost:3000/docs/billing
- verify that the descriptions in the list items have an applied maxWidth of 1150 (35rem)
- navigate to http://localhost:3000/docs/billing/common-billing-errors
- verify that the description (or last updated div wrapper) in the header has an applied maxWidth of 1150 (35rem)