### PR TITLE
WE-160: remove disallow in next-sitemap.js

### DIFF
--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -6,7 +6,6 @@ module.exports = {
     policies: [
       {
         userAgent: '*',
-        disallow: ['*'],
       },
     ],
   },


### PR DESCRIPTION
### What Changed
Removes the 'disallow' policy in the next-sitemap.js file. The `robots.txt` build file is managed by the next-sitemap plugin.

### How To Test or Verify
- run `npm run build`
- wait for completion of build
- open the /public/robots.txt file
- verify `Disallow: *` no longer exists in the file under the `*` policy.