### PR TITLE
WE-375: Conditionally link 404 page to /momentum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn-error.log*
 
 # Auto generated images
 public/content
+
+# Netlify
+.netlify/*

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ yarn-error.log*
 public/content
 
 # Netlify
-.netlify/*
+/.netlify/

--- a/components/site/header.tsx
+++ b/components/site/header.tsx
@@ -17,8 +17,8 @@ type HeaderProps = {
 
 const Header = (props: HeaderProps) => {
   const { getActivatorProps } = props;
-  const { route } = useRouter();
-  const category = route.split('/')[1];
+  const { asPath } = useRouter();
+  const category = asPath.split('/')[1];
 
   return (
     <Box my="600">

--- a/components/site/layout.tsx
+++ b/components/site/layout.tsx
@@ -12,8 +12,8 @@ type LayoutProps = {
 const Layout = (props: LayoutProps): JSX.Element => {
   const { children, navigationComponent } = props;
   const { getDrawerProps, getActivatorProps } = useDrawer();
-  const { route } = useRouter();
-  const category = route.split('/')[1];
+  const { asPath } = useRouter();
+  const category = asPath.split('/')[1];
 
   return (
     <LayoutWrap>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import type { NextPage } from 'next';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import SEO from 'components/site/seo';
 import LayoutWrap from 'components/site/layoutWrap';
 import LayoutInnerContent from 'components/site/layoutInnerContent';
@@ -24,6 +25,9 @@ const StyledLink = styled(Box)`
 `;
 
 const OhhhNoes: NextPage = () => {
+  const { asPath } = useRouter();
+  const category = asPath.split('/')[1];
+
   return (
     <>
       <SEO
@@ -67,7 +71,7 @@ const OhhhNoes: NextPage = () => {
                 my={['400', null, '500']}
               >
                 Return to{' '}
-                <Link href="/docs" passHref>
+                <Link href={`/${category}`} passHref>
                   <StyledLink as="a" href="/docs">
                     Home
                   </StyledLink>
@@ -81,7 +85,6 @@ const OhhhNoes: NextPage = () => {
               justifyContent="center"
               width="100%"
               mt="500"
-              // mb={['700', null, '434px']}
               mb="700"
             >
               <Image


### PR DESCRIPTION
### What Changed

Makes the 404 page dynamic based on which category you are in.

### How To Test or Verify

- navigate to a page that doesn't exist in the `/docs` category (/docs/nopeynopenopenope)
- expect that the link to "home" goes to `/docs`
- expect search to search the `/docs` site

- navigate to a page that doesn't exist in the `/momentum` category (/momentum/nopeynopenopenope)
- expect that the link to "home" goes to `/momentum`
- expect search to search the `/momentum` site