### PR TITLE
Remove line numbers in code blocks

### DIFF
--- a/components/markdown/code.tsx
+++ b/components/markdown/code.tsx
@@ -44,7 +44,6 @@ const Code = (props: CodeProps): JSX.Element | null => {
       <SyntaxHighlighter
         language={language || 'text'}
         style={a11yDark}
-        showLineNumbers
         PreTag={Pre}
       >
         {String(children).replace(/\n$/, '')}


### PR DESCRIPTION
## How to Test?
 * Open any page that has a code block, for example https://support.sparkpost.com/docs/tech-resources/enabling-https-engagement-tracking-on-sparkpost
 * Confirm that the code block no longer has line numbers on left side