### PR TITLE
FE-1591: Nested routes in support docs are not routed correct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn-error.log*
 
 # Auto generated images
 public/content
+
+# Netlify
+.netlify/

--- a/components/markdown/link.tsx
+++ b/components/markdown/link.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { Box } from '@sparkpost/matchbox';
 import styled from 'styled-components';
 import css from '@styled-system/css';
+import { useRouter } from 'next/router';
 
 const StyledLink = styled(Box)`
   &,
@@ -25,9 +26,24 @@ export type LinkProps = React.ComponentPropsWithoutRef<'a'> & {
 };
 
 const AnchorLink = (props: LinkProps): JSX.Element => {
+  const router = useRouter();
+  const checkLink = (href: string): string => {
+    let link = href;
+    if (href.startsWith('./') && !href.includes('./media')) {
+      let routeComponents = router.asPath.split('/');
+      routeComponents.pop();
+
+      let updatedHref = href.replace('./', '');
+      routeComponents.push(updatedHref);
+
+      link = routeComponents.join('/');
+    }
+    return link;
+  };
+
   return (
-    <Link passHref href={props.href || '/'}>
-      <StyledLink as="a" href={props.href}>
+    <Link passHref href={checkLink(props.href || '/')}>
+      <StyledLink as="a" href={checkLink(props.href || '/')}>
         {props.children}
       </StyledLink>
     </Link>

--- a/components/markdown/link.tsx
+++ b/components/markdown/link.tsx
@@ -31,6 +31,13 @@ const AnchorLink = (props: LinkProps): JSX.Element => {
     let link = href;
     if (href.startsWith('./') && !href.includes('./media')) {
       const routeComponents = router.asPath.split('/');
+
+      // Trailing slashes
+      if (!routeComponents[routeComponents.length - 1]) {
+        routeComponents.pop();
+      }
+
+      // Remove the last item in the url since we're staying in the same directory
       routeComponents.pop();
 
       const updatedHref = href.replace('./', '');

--- a/components/markdown/link.tsx
+++ b/components/markdown/link.tsx
@@ -30,10 +30,10 @@ const AnchorLink = (props: LinkProps): JSX.Element => {
   const checkLink = (href: string): string => {
     let link = href;
     if (href.startsWith('./') && !href.includes('./media')) {
-      let routeComponents = router.asPath.split('/');
+      const routeComponents = router.asPath.split('/');
       routeComponents.pop();
 
-      let updatedHref = href.replace('./', '');
+      const updatedHref = href.replace('./', '');
       routeComponents.push(updatedHref);
 
       link = routeComponents.join('/');

--- a/components/site/docsIndexListPageContent.tsx
+++ b/components/site/docsIndexListPageContent.tsx
@@ -13,7 +13,6 @@ const DocsIndexListPageContent = (props: DocsIndexListPageContentProps) => {
   const postsPerClick = 7;
   const [paginationCount, setPaginationCount] = useState<number>(postsPerClick);
   const { navigationData } = props;
-  console.log('DocsIndexListPageContent props', props);
   return (
     <>
       {navigationData && navigationData.items ? (

--- a/components/site/docsIndexListPageContent.tsx
+++ b/components/site/docsIndexListPageContent.tsx
@@ -13,6 +13,7 @@ const DocsIndexListPageContent = (props: DocsIndexListPageContentProps) => {
   const postsPerClick = 7;
   const [paginationCount, setPaginationCount] = useState<number>(postsPerClick);
   const { navigationData } = props;
+  console.log('DocsIndexListPageContent props', props);
   return (
     <>
       {navigationData && navigationData.items ? (

--- a/content/momentum/4/operations-riak-backups.md
+++ b/content/momentum/4/operations-riak-backups.md
@@ -1,14 +1,14 @@
 ---
-lastUpdated: "03/26/2020"
-title: "Backups"
-description: "Riak data is distributed across the nodes in the cluster Provided that you have enough nodes remaining online the need to restore from a backup should be quite a rare event Riak offers the ability to backup all data present on a given node or all data present in the..."
+lastUpdated: '03/26/2020'
+title: 'Backups'
+description: 'Riak data is distributed across the nodes in the cluster Provided that you have enough nodes remaining online the need to restore from a backup should be quite a rare event Riak offers the ability to backup all data present on a given node or all data present in the...'
 ---
 
 Riak data is distributed across the nodes in the cluster. Provided that you have enough nodes remaining online, the need to restore from a backup should be quite a rare event.
 
 Riak offers the ability to backup all data present on a given node or all data present in the cluster. The backup is stored in a file named by the administrator. This backup can later be used to restore the state of the node or cluster depending on the nature of the backup file.
 
-For details about backing up Riak, consult the [Riak](http://http://docs.basho.com/riak/latest/) documentation.
+For details about backing up Riak, consult the [Riak](http://docs.basho.com/riak/latest/) documentation.
 
 ### Note
 

--- a/content/momentum/4/operations-riak-ports.md
+++ b/content/momentum/4/operations-riak-ports.md
@@ -1,21 +1,21 @@
 ---
-lastUpdated: "03/26/2020"
-title: "Riak Ports"
-description: "Riak uses the following ports TCP 8098 Defines the HTTP interface used to query and update the data store By default this is bound to the loopback interface but will need to be opened on a cluster private network so that Message Systems applications can communicate with it The port..."
+lastUpdated: '03/26/2020'
+title: 'Riak Ports'
+description: 'Riak uses the following ports TCP 8098 Defines the HTTP interface used to query and update the data store By default this is bound to the loopback interface but will need to be opened on a cluster private network so that Message Systems applications can communicate with it The port...'
 ---
 
 Riak uses the following ports:
 
-*   `TCP 8098` – Defines the HTTP interface used to query and update the data store. By default, this is bound to the loopback interface but will need to be opened on a cluster private network so that Message Systems applications can communicate with it. The port and IP addresses used for HTTP are controlled by the `http` setting in `app.config`.
+- `TCP 8098` – Defines the HTTP interface used to query and update the data store. By default, this is bound to the loopback interface but will need to be opened on a cluster private network so that Message Systems applications can communicate with it. The port and IP addresses used for HTTP are controlled by the `http` setting in `app.config`.
 
-*   `TCP 8099` – Defines the cluster handoff protocol interface used by Riak to synchronize its data. This port needs to be opened on a cluster private network so that Riak nodes can talk to each other. The port and IP address used for handoff are controlled by the `handoff_port` and `handoff_ip` settings in `app.config`.
+- `TCP 8099` – Defines the cluster handoff protocol interface used by Riak to synchronize its data. This port needs to be opened on a cluster private network so that Riak nodes can talk to each other. The port and IP address used for handoff are controlled by the `handoff_port` and `handoff_ip` settings in `app.config`.
 
-*   `TCP 8087` – Defines an alternative "Protocol Buffers" interface for querying Riak. This is not used by Message Systems and is disabled in our default packaging.
+- `TCP 8087` – Defines an alternative "Protocol Buffers" interface for querying Riak. This is not used by Message Systems and is disabled in our default packaging.
 
-*   `TCP 4369` – In a cluster configuration Riak uses the Erlang Port Mapper daemon (epmd) to resolve node identifiers. By default epmd binds to port 4369\. For more information, see [the section called “Erlang and Firewalls”](/momentum/4/operations-riak-ports#operations.riak.ports.erlang).
+- `TCP 4369` – In a cluster configuration Riak uses the Erlang Port Mapper daemon (epmd) to resolve node identifiers. By default epmd binds to port 4369\. For more information, see [the section called “Erlang and Firewalls”](/momentum/4/operations-riak-ports#operations.riak.ports.erlang).
 
 None of these ports should be exposed to the public Internet; we strongly recommend that access to these ports from untrusted networks be blocked by a firewall.
 
 ### <a name="operations.riak.ports.erlang"></a> Erlang and Firewalls
 
-The maximum number of concurrent ports used by Erlang is defined in the `/opt/msys/3rdParty/riak/etc/vm.args` file by the variable `ERL_MAX_PORTS`. If port usage needs to be restricted, we recommend defining a range of ports equal to the number of nodes in the cluster. For details on network security and firewall configurations, consult the [Riak](http://http://docs.basho.com/riak/latest/) documentation.
+The maximum number of concurrent ports used by Erlang is defined in the `/opt/msys/3rdParty/riak/etc/vm.args` file by the variable `ERL_MAX_PORTS`. If port usage needs to be restricted, we recommend defining a range of ports equal to the number of nodes in the cluster. For details on network security and firewall configurations, consult the [Riak](http://docs.basho.com/riak/latest/) documentation.

--- a/content/momentum/4/riak.md
+++ b/content/momentum/4/riak.md
@@ -1,30 +1,29 @@
 ---
-lastUpdated: "03/26/2020"
-title: "Riak"
-description: "Riak is a distributed key value data storage technology with excellent scalability properties It is used by the adaptive module Adaptive Delivery reporting and Mobile Momentum for resubmission of messages Riak is freely available for use in a LAN deployment but WAN deployments that need to be synchronized require a..."
+lastUpdated: '03/26/2020'
+title: 'Riak'
+description: 'Riak is a distributed key value data storage technology with excellent scalability properties It is used by the adaptive module Adaptive Delivery reporting and Mobile Momentum for resubmission of messages Riak is freely available for use in a LAN deployment but WAN deployments that need to be synchronized require a...'
 ---
 
-
-<a name="idp3607504"></a> 
+<a name="idp3607504"></a>
 
 Riak is a distributed key-value data storage technology with excellent scalability properties. It is used by the [adaptive](/momentum/4/modules/4-adaptive) module, Adaptive Delivery reporting, and Mobile Momentum for resubmission of messages.
 
-Riak is freely available for use in a LAN deployment, but WAN deployments that need to be synchronized require a commercially licensed variant. Note that multiple data centers may still use Riak if each data center has its own local Riak cluster. For more information, see the [Riak](http://http://docs.basho.com/riak/latest/) documentation.
+Riak is freely available for use in a LAN deployment, but WAN deployments that need to be synchronized require a commercially licensed variant. Note that multiple data centers may still use Riak if each data center has its own local Riak cluster. For more information, see the [Riak](http://docs.basho.com/riak/latest/) documentation.
 
 ## <a name="riak.overview"></a> Riak Overview
 
 The following describes the default directories and configuration related to the Riak database:
 
-*   `/opt/msys/3rdParty/riak/` – Riak packages provided by Message Systems are installed under this path.
+- `/opt/msys/3rdParty/riak/` – Riak packages provided by Message Systems are installed under this path.
 
-*   `/opt/msys/3rdParty/riak/bin` – Administrative tools for Riak are provided under this path. These tools are named "`riak`", "`riak-admin`" and "`search-cmd`".
+- `/opt/msys/3rdParty/riak/bin` – Administrative tools for Riak are provided under this path. These tools are named "`riak`", "`riak-admin`" and "`search-cmd`".
 
-*   `/opt/msys/3rdParty/riak/etc` – Contains the main configuration file named `app.config` and an additional configuration file named `vm.args`. The contents of `app.config` are formatted as an Erlang "term"; a structured file with meaningful "keys" and "values". The file is terminated with a period ‘`.`’ character. The `vm.args` file includes the unique names of the nodes in a cluster, as specified with the "-name" parameter switch.
+- `/opt/msys/3rdParty/riak/etc` – Contains the main configuration file named `app.config` and an additional configuration file named `vm.args`. The contents of `app.config` are formatted as an Erlang "term"; a structured file with meaningful "keys" and "values". The file is terminated with a period ‘`.`’ character. The `vm.args` file includes the unique names of the nodes in a cluster, as specified with the "-name" parameter switch.
 
-*   `/var/db/riak` – The default configuration for Momentum's Riak package stores Riak state at this location.
+- `/var/db/riak` – The default configuration for Momentum's Riak package stores Riak state at this location.
 
-    During installation there is no prompt for an alternative data storage location; instead, the system administrator may opt to partition the system such that `/var/db/riak` maps to its own set of spindles prior to installation or may choose to mount alternative storage. In the latter case, the administrator will need to edit `app.config` and change the paths that refer to `/var/db/riak` to the alternate location.
+  During installation there is no prompt for an alternative data storage location; instead, the system administrator may opt to partition the system such that `/var/db/riak` maps to its own set of spindles prior to installation or may choose to mount alternative storage. In the latter case, the administrator will need to edit `app.config` and change the paths that refer to `/var/db/riak` to the alternate location.
 
-*   `/var/log/riak` – Contains log files.
+- `/var/log/riak` – Contains log files.
 
 For additional details about configuration, see [“Configuring Riak in a Cluster”](/momentum/4/cluster-riak-configuration).

--- a/cypress/content/momentum/1st-level/relative-link-test.md
+++ b/cypress/content/momentum/1st-level/relative-link-test.md
@@ -1,0 +1,7 @@
+---
+lastUpdated: '01/04/2022'
+title: 'Relative Link Test Page'
+description: 'This is to verify that relative linking in current directory works as expected'
+---
+
+Does it work? Idk, but I hope so!

--- a/cypress/content/momentum/1st-level/test.md
+++ b/cypress/content/momentum/1st-level/test.md
@@ -50,8 +50,11 @@ This is an ordered list:
 
 You can link to external resources using this format: `[text here](link here)`. For example:
 
+- [Duck, duck, GO! (quick check)](https://duckduckgo.com/)
 - [SparkPost website](https://www.sparkpost.com)
 - [SparkPost API docs](https://developers.sparkpost.com/api)
+- [Relative to current directory Link](./relative-link-test)
+- [Internal Link](/momentum/1st-level)
 
 ### Images
 

--- a/cypress/integration/subpage.spec.ts
+++ b/cypress/integration/subpage.spec.ts
@@ -1,11 +1,38 @@
-describe('Sub section index page', () => {
-  it('Should display without error', () => {
-    cy.visit('/momentum/1st-level');
+describe('Sub section page', () => {
+  describe('index page in sub section', () => {
+    it('Should display without error', () => {
+      cy.visit('/momentum/1st-level');
+    });
   });
-});
 
-describe('Sub section test page', () => {
-  it('Should display without error', () => {
-    cy.visit('/momentum/1st-level/test');
+  describe('test page in subsection', () => {
+    it('Should display without error', () => {
+      cy.visit('/momentum/1st-level/test');
+    });
+  });
+
+  describe('links', () => {
+    it('Should work as expected for external links', () => {
+      cy.visit('/momentum/1st-level/test');
+
+      cy.get('a')
+        .contains('Duck, duck, GO! (quick check)')
+        .then(($a) => {
+          const url = $a.prop('href');
+          cy.request(url).its('body').should('include', '</html>');
+        });
+    });
+
+    it('Should work as expected for internal links', () => {
+      cy.visit('/momentum/1st-level/test');
+      cy.contains('Internal Link').click();
+      cy.location('pathname').should('eq', '/momentum/1st-level');
+    });
+
+    it('Should allow for relative links in the current directory', () => {
+      cy.visit('/momentum/1st-level/test');
+      cy.contains('Relative to current directory Link').click();
+      cy.location('pathname').should('eq', '/momentum/1st-level/relative-link-test');
+    });
   });
 });

--- a/cypress/integration/subpage.spec.ts
+++ b/cypress/integration/subpage.spec.ts
@@ -26,13 +26,13 @@ describe('Sub section page', () => {
     it('Should work as expected for internal links', () => {
       cy.visit('/momentum/1st-level/test');
       cy.contains('Internal Link').click();
-      cy.location('pathname').should('eq', '/momentum/1st-level');
+      cy.location('pathname').should('eq', '/momentum/1st-level/');
     });
 
     it('Should allow for relative links in the current directory', () => {
       cy.visit('/momentum/1st-level/test');
       cy.contains('Relative to current directory Link').click();
-      cy.location('pathname').should('eq', '/momentum/1st-level/relative-link-test');
+      cy.location('pathname').should('eq', '/momentum/1st-level/relative-link-test/');
     });
   });
 });

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -73,7 +73,7 @@ export const getSupportNavigation = () => {
   const categories = glob.sync('content/docs/**/index.md');
   const categoryData = categories.map((file) => {
     const { data } = readFile(file);
-    const link = file.replace(/\/index.md$/, '').replace(/^content/, '');
+    const link = file.replace(/\/index.md$/, '/').replace(/^content/, '');
     return { ...data, link };
   });
 
@@ -84,7 +84,8 @@ export const getSupportNavigation = () => {
       ...category,
       items: postsInCategory.map((file) => {
         const { data } = readFile(file);
-        const link = file.replace(/.md$/, '').replace(/^content/, '');
+        const link = file.replace(/.md$/, '/').replace(/^content/, '');
+        // console.log('postsInCategory link', link);
         return { ...data, link };
       }),
     };

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -85,7 +85,6 @@ export const getSupportNavigation = () => {
       items: postsInCategory.map((file) => {
         const { data } = readFile(file);
         const link = file.replace(/.md$/, '/').replace(/^content/, '');
-        // console.log('postsInCategory link', link);
         return { ...data, link };
       }),
     };

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="next" />
+/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -30,12 +30,6 @@ type PostPageProps = {
 const PostPage = (props: PostPageProps): JSX.Element => {
   const { content, data, navigationData, isIndex, categoryData } = props;
   const router = useRouter();
-  console.log('PostPage props', props);
-  console.log('PostPage router path', router.asPath);
-  console.log(
-    'PostPage props find filtered',
-    navigationData ? navigationData.find((navData) => navData.link === router.asPath) : 'nada',
-  );
   return (
     <CategoriesProvider data={categoryData}>
       <SEO title={data.title} description={data.description} />

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -30,6 +30,15 @@ type PostPageProps = {
 const PostPage = (props: PostPageProps): JSX.Element => {
   const { content, data, navigationData, isIndex, categoryData } = props;
   const router = useRouter();
+
+  // This is to check for a url that either contains a trailing slash or not (since netlify will show either)
+  const trailingSlashOrNo = (navData: NavigationItemProps): boolean => {
+    const linkComponents = navData.link.split('/');
+    linkComponents.pop();
+    const link = linkComponents.join('/');
+
+    return link === router.asPath || link + '/' === router.asPath;
+  };
   return (
     <CategoriesProvider data={categoryData}>
       <SEO title={data.title} description={data.description} />
@@ -41,9 +50,7 @@ const PostPage = (props: PostPageProps): JSX.Element => {
           description={data.description}
         >
           {isIndex && navigationData ? (
-            <DocsIndexListPageContent
-              navigationData={navigationData.find((navData) => navData.link === router.asPath)}
-            />
+            <DocsIndexListPageContent navigationData={navigationData.find(trailingSlashOrNo)} />
           ) : (
             <Markdown>{content}</Markdown>
           )}

--- a/pages/docs/[...slug].tsx
+++ b/pages/docs/[...slug].tsx
@@ -30,6 +30,12 @@ type PostPageProps = {
 const PostPage = (props: PostPageProps): JSX.Element => {
   const { content, data, navigationData, isIndex, categoryData } = props;
   const router = useRouter();
+  console.log('PostPage props', props);
+  console.log('PostPage router path', router.asPath);
+  console.log(
+    'PostPage props find filtered',
+    navigationData ? navigationData.find((navData) => navData.link === router.asPath) : 'nada',
+  );
   return (
     <CategoriesProvider data={categoryData}>
       <SEO title={data.title} description={data.description} />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -21,29 +17,12 @@
     "incremental": true
   },
   "paths": {
-    "@content/*": [
-      "content/*"
-    ],
-    "@lib/*": [
-      "lib/*"
-    ],
-    "@utils/*": [
-      "utils/*"
-    ],
-    "@hooks/*": [
-      "hooks/*"
-    ],
-    "@context/*": [
-      "context/*"
-    ]
+    "@content/*": ["content/*"],
+    "@lib/*": ["lib/*"],
+    "@utils/*": ["utils/*"],
+    "@hooks/*": ["hooks/*"],
+    "@context/*": ["context/*"]
   },
-  "include": [
-    "next-env.d.ts",
-    "yaml.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "yaml.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### What Changed

Adds a filter for links being passed to the link components to recognize relative urls and change them to the correct 'catch all' path.

### How To Test or Verify

- navigate to the deploy preview link
- navigate to `/docs/recipient-validation/getting-started-recipient-validation`
- click "validate your email lists"
- verify it goes to `/docs/recipient-validation/validate-an-email-list`
- navigate to `/docs/billing/upgrading-your-account`
- verify that the images still display
- on the same page (`/docs/billing/upgrading-your-account`), near the bottom, click on "Sales team"
- verify that the link works as expected (navigates to `https://www.sparkpost.com/sales/?_ga=2.162836475.692581547.1641240702-814180327.1638910212`)

### PR Checklist

- [x] Give your pull request a meaningful name.
- [x] Use lowercase filenames.
- [x] Pull request approval from the FE team or content experts that isn't the content creator.
- [x] The appropriate tests are created in `cypress/` directory in the root of the project