### PR TITLE
WE-421: broken image links

### DIFF
--- a/components/markdown/image.tsx
+++ b/components/markdown/image.tsx
@@ -5,10 +5,14 @@ import { Box } from '@sparkpost/matchbox';
 
 const getImageSrc = (asPath: string, src?: string) => {
   const environment = getWindow();
-  const parts = asPath.split('/');
-  const dirArr = parts.splice(0, parts.length - 1);
-  dirArr.pop();
-  const dir = dirArr.join('/');
+  const pathArr = asPath.split('/');
+
+  // Check for 'trailing slash'
+  if (!pathArr[pathArr.length - 1]) {
+    pathArr.pop();
+  }
+  pathArr.pop();
+  const dir = pathArr.join('/');
   const path = `${environment?.location.origin || 'https://localhost:3000'}/content${dir}/${src}`;
   return path;
 };


### PR DESCRIPTION
### What Changed

Adds case for both trailing slash and non trailing slash situations since netlify will have both.

### How To Test or Verify
To test on netlify
- use the deploy preview link in the PR
- than continue with steps below

OR

To test locally
- pull this branch and open `next.config.js`
- to test with trailing slash, keep `trailingSlash: true,` (line 7) uncommented
- to test without trailing slash, comment out `trailingSlash: true,` (line 7)

- navigate to `/docs/getting-started/getting-started-sparkpost` (notice no trailing slash)
- observe that the images load as expected
- in the left navigation, go to "Getting Started" > "Getting Started with SparkPost" and click
- observe the link in the top and confirm it is `/docs/getting-started/getting-started-sparkpost/` (with a trailing slash)
- observe that the images load as expected

### PR Checklist

- [x] Give your pull request a meaningful name.
- [x] Use lowercase filenames.
- [x] Apply at least one team label according to which team is the content expert (ie. `team-FE` or `team-SAZ`)
- [x] Pull request approval from the FE team or content experts (see label applied above) that isn't the content creator.
- [x] The appropriate tests are created in `cypress/` directory in the root of the project