### PR TITLE
Fix webhook page with wrong style

### DIFF
--- a/content/docs/tech-resources/webhook-event-reference.md
+++ b/content/docs/tech-resources/webhook-event-reference.md
@@ -14,21 +14,21 @@ Additional resources: [Webhook Authentication](https://www.sparkpost.com/docs/te
 
 Events which are sent from SparkPost webhooks are organized into different event types. Below is a table that provides you with a list of these event types and map containing each event which fall into their respective event types.
 
-<div id="content-event-types"></div>
+<div id="content-event-types" style="margin: 0 1.5rem"></div>
 <script id="event-type-template" type="text/x-handlebars-template"><table id="event-types"> <thead> <tr> <td>Event Type</td> <td>JSON Key</td> <td>Description</td> <td>Events</td> </tr> </thead> <tbody> {{#each this}} <tr> <td>{{ name }}</td> <td>{{ key }}</td> <td>{{ description }}</td> <td>{{ events }}</td> </tr> {{/each}} </tbody> </table></script>
 
 ## Events
 
 Each event which SparkPost sends you about your email transmissions has some valuable recipient-level information about every email SparkPost sends on your domain's behalf. EVERY event created by SparkPost has a "type" property which refers to the Event Type JSON Key.
 
-<div id="content-events"></div>
+<div id="content-events" style="margin: 0 1.5rem"></div>
 <script id="events-template" type="text/x-handlebars-template"><table id="events"> <thead> <tr> <td>Event</td> <td>JSON Key</td> <td>Description</td> <td>Event Properties(full description below)</td> </tr> </thead> <tbody> {{#each this}} <tr> <td>{{ name }}</td> <td>{{ key }}</td> <td>{{ description }}</td> <td>{{ props }}</td> </tr> {{/each}} </tbody> </table></script>
 
 ## Event Properties
 
 Each event has different properties which are described below for your reference.You can also use the SparkPost API Webhook resource's [List sample values and event descriptions](https://developers.sparkpost.com/api/#/reference/webhooks/events-documentation) to see a complete set of event properties mapped to each event type.
 
-<div id="content-event-props"></div>
+<div id="content-event-props" style="margin: 0 1.5rem"></div>
 <script id="event-props-template" type="text/x-handlebars-template"> <table id="events"> <thead> <tr> <td>JSON Key</td> <td>Description</td> <td>Sample Value</td> </tr> </thead> <tbody> {{#each this}} <tr> <td>{{ key }}</td> <td>{{ description }}</td> <td>{{ sample }}</td> </tr> {{/each}} </tbody> </table> </script>
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.3/handlebars.min.js"></script>


### PR DESCRIPTION
### What Changed

- Adds correct margin to webhook table.

### How To Test or Verify

- Go to https://deploy-preview-660--support-docs.netlify.app/docs/tech-resources/webhook-event-reference
- Check if `Event Types` margin is correct.

### PR Checklist

Below are some checklists to follow for the correct procedure in different circumstance. The first list ("All PRs Checklist") should be followed for ALL PRs. The next 2 are additive to this list depending on what type of PR you are using.

For example: If you are submitting a content change to one of the support documents, your checklist would include the:

- "All PRs Checklist"
- AND the "Content Changes Checklist

If you are submitting a feature addition, enhancement, or bug fix, your checklist would include the:

- "All PRs Checklist"
- AND the "Development Changes Checklist"

#### All PRs Checklist

- [x] Give your pull request a meaningful name.
- [x] Use lowercase filenames.
- [x] Apply at least one team label according to which team is the content expert (ie. `team-FE` or `team-SAZ`)
- [ ] Pull request approval from the FE team or content experts (see label applied above) that isn't the content creator.

#### Content Changes Checklist

- [ ] Check that your article looks correct in the preview here or in a [Netlify deploy preview](https://app.netlify.com/sites/support-docs/deploys).
- [ ] Check the links in your article.
- [ ] Check the images in your article (if there are any)
- [ ] Check to make sure you are using markdown appropriately as outlined in `examples/article.md` in the root of the project directory and on the momentum doc's [preface article](https://support.sparkpost.com/momentum/4/4-preface)
- [ ] Check to make sure the [Copy and Tone Guidelines are followed](https://docs.google.com/document/d/1dej9J7N9M8lcbJXnT9kxyNB_EFBPHIBLZBbHaxRWqhQ/edit).

#### Development Changes Checklist (some checks are automatic github actions and will not be listed here. ie. "all tests pass")

- [ ] The appropriate tests are created in `cypress/` directory in the root of the project
- [ ] The lighthouse score is passing according to the [FE Support Docs' Service Outline](https://sparkpost.atlassian.net/wiki/spaces/ENG/pages/1238728726/FE+Support+Docs) SLI/SLOs
