### PR TITLE
FE-1644 - Add Strict Transport Security Header to support-docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,15 @@ publish = ".next"
 [[plugins]]
 package = "@netlify/plugin-nextjs"
 
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover.
+  for = "/*"
+
+  [headers.values]
+    Strict-Transport-Security = '''
+    max-age=31536000;
+    includeSubDomains;'''
+    
 # A redirect rule with many of the supported properties
 [[redirects]]
   from = "/"


### PR DESCRIPTION
### What Changed

- Added the HSTS header 
- Added the Max Age of HSTS header for 1 year.  This header tells the user agent only connect to the site and subdomains via HTTPS for the next 1 year. We have had it set to 60 days for about 2 years without encountering issues due to it, so its safe to increase the max age. 
- Added includeSubDomains to the HSTS header, This directive notifies the browser that all subdomains of the current origin should also be upgraded via HSTS. For example, setting includeSubDomains on developers.sparkpost.com will also set it on host1.app-staging.sparkpost.com and host2.developers.sparkpost.com. 

***It is advised to practice extreme care when setting the includeSubDomains flag, as it could disable sites on subdomains that don’t yet have HTTPS enabled.  - but we should be good since we don't have subdomains for developers.sparkpost.com in use. [need to verify this]***

### PR Checklist

#### Development Changes Checklist (some checks are automatic github actions and will not be listed here. ie. "all tests pass")

- [ ] The appropriate tests are created in `cypress/` directory in the root of the project
- [ ] The lighthouse score is passing according to the [FE Support Docs' Service Outline](https://sparkpost.atlassian.net/wiki/spaces/ENG/pages/1238728726/FE+Support+Docs) SLI/SLOs
