### PR TITLE
FE-1658 Text in tables shouldn't wrap in the middle of a word in the help docs

### DIFF
--- a/components/markdown/index.tsx
+++ b/components/markdown/index.tsx
@@ -40,7 +40,7 @@ const components = {
   ol: Ol,
   blockquote: BlockQuote,
   tr: (props: MarkdownComponentProps) => <MBTable.Row {...props} />,
-  td: (props: MarkdownComponentProps) => <MBTable.Cell {...props} />,
+  td: (props: MarkdownComponentProps) => <MBTable.Cell {...props} style={{ wordBreak: 'normal' }} />,
   th: (props: MarkdownComponentProps) => <MBTable.HeaderCell {...props} />,
 };
 


### PR DESCRIPTION
### What Changed

- Prevent word to be broken in the middle.

### How To Test or Verify

- Go to a page with table (i.e /docs/deliverability/bounce-classification-codes/)
- Check if the words in table are not being broken in the middle.