### PR TITLE
SD-3759 Documented the adaptive force_max_binding_age option

### DIFF
--- a/content/momentum/4/modules/4-adaptive.md
+++ b/content/momentum/4/modules/4-adaptive.md
@@ -304,6 +304,16 @@ Specify the name of a persisted named series to be used to hold the total delive
 
 </dd>
 
+<dt><a name="modules.adaptive.force_max_binding_age"></a> force_max_binding_age</dt>
+
+<dd>
+
+Introduced in Momentum 4.4.
+
+If set to `true`, when calculating message throttles, adaptive will treat all binding ages as the maximum age.  It may be beneficial to set this to true if you regularly introduce new bindings which you know are associated with already warm outbound sending IPs.  This will avoid the need to use the adaptive warmup ec_console command on each binding.  Default value is `false`.
+
+</dd>
+
 <dt><a name="modules.adaptive.jlog_file"></a> jlog_file</dt>
 
 <dd>


### PR DESCRIPTION
### What Changed

This adaptive option was introduced in Momentum 4.4 but we never documented it.  See https://sparkpost.atlassian.net/browse/SD-3759.

#### Content Changes Checklist

- [ ] Check that your article looks correct in the preview here or in a [Netlify deploy preview](https://app.netlify.com/sites/support-docs/deploys).
- [ ] Check the links in your article.
- [ ] Check the images in your article (if there are any)
- [ ] Check to make sure you are using markdown appropriately as outlined in `examples/article.md` in the root of the project directory and on the momentum doc's [preface article](https://support.sparkpost.com/momentum/4/4-preface)
- [ ] Check to make sure the [Copy and Tone Guidelines are followed](https://docs.google.com/document/d/1dej9J7N9M8lcbJXnT9kxyNB_EFBPHIBLZBbHaxRWqhQ/edit).

#### Development Changes Checklist (some checks are automatic github actions and will not be listed here. ie. "all tests pass")

- [ ] The appropriate tests are created in `cypress/` directory in the root of the project
- [ ] The lighthouse score is passing according to the [FE Support Docs' Service Outline](https://sparkpost.atlassian.net/wiki/spaces/ENG/pages/1238728726/FE+Support+Docs) SLI/SLOs
