### PR TITLE
Updated max-request-size.md

### DIFF
--- a/content/momentum/4/config/max-request-size.md
+++ b/content/momentum/4/config/max-request-size.md
@@ -1,7 +1,7 @@
 ---
-lastUpdated: "03/26/2020"
+lastUpdated: "08/06/2025"
 title: "max_request_size"
-description: "max request size maximum size of an HTTP request Max Recipients Per Connection 102400 This option limits the size of an HTTP request If this option is not set there is no limit max request size is valid in the http listener listen pathway pathway group and peer scopes..."
+description: "max request size maximum size of an HTTP request Max Request Size 50000 This option limits the size of an HTTP request. If this option is not set there is no limit max request size is valid in the http listener listen pathway pathway group and peer scopes..."
 ---
 
 <a name="config.max_request_size"></a> 
@@ -11,7 +11,7 @@ max_request_size — maximum size of an HTTP request
 
 ## Synopsis
 
-`Max_Recipients_Per_Connection = 102400`
+`Max_Request_Size = 50000`
 
 <a name="idp25273664"></a> 
 ## Description


### PR DESCRIPTION
TASK-48550

Updated max-request-size.md to correct Synopsis and description sections, as they previously showed `Max_Recipients_Per_Connection = 102400`


