### PR TITLE
TASK-91082: Announce `dnsbuf` module deprecation

### DIFF
--- a/content/momentum/3/3-reference/3-reference-modules-dnsbuf.md
+++ b/content/momentum/3/3-reference/3-reference-modules-dnsbuf.md
@@ -8,7 +8,7 @@ description: "Configuration Change This feature is available as beta in Momentum
 
 **Configuration Change.** This feature is available as beta in Momentum 3.6.5.
 
-> **NOTE: This feature was DEPRECATED in Momentum 4.8 and is not supported anymore.**
+> **NOTE: This feature was DEPRECATED in Momentum 4.8 and is no longer supported.**
 
 Momentum does not manipulate the size of UDP sockets it creates and uses for DNS queries; instead, it will use the default sizes configured by the Operating System. This can create problems for clients with too many domains (e.g., tens of thousands) in the system. Responses may be dropped, causing unnecessary DNS failures and retries, thus further increasing the DNS query volume. The `dnsbuf` module enables the client to manipulate the DNS buffer sizes on demand, on the fly.
 

--- a/content/momentum/4/modules/dnsbuf.md
+++ b/content/momentum/4/modules/dnsbuf.md
@@ -8,7 +8,7 @@ description: "Configuration Change This feature is available in Momentum 4 2 and
 
 **Configuration Change.** This feature is available from Momentum 4.2 through 4.7.
 
-> **NOTE: This feature was DEPRECATED in Momentum 4.8 and is not supported anymore.**
+> **NOTE: This feature was DEPRECATED in Momentum 4.8 and is no longer supported.**
 
 Momentum does not manipulate the size of UDP sockets it creates and uses for DNS queries; instead, it will use the default sizes configured by the Operating System. This can create problems for clients with too many domains (e.g., tens of thousands) in the system. Responses may be dropped, causing unnecessary DNS failures and retries, thus further increasing the DNS query volume. The `dnsbuf` module enables the client to manipulate the DNS buffer sizes on demand, on the fly.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Announces dnsbuf deprecation (removed in 4.8) and updates Momentum 3/4 docs with availability, guidance, and minor formatting tweaks.
> 
> - **Documentation updates for `dnsbuf`**:
>   - **Deprecation**: Added note that `dnsbuf` was deprecated in Momentum 4.8 and is no longer supported (Momentum 3 and 4 pages).
>   - **Availability clarified**: Momentum 4 page now states availability from `4.2` through `4.7`.
>   - **Configuration example**: Updated comments to note Linux buffer sizes are set to `131072`.
>   - **Monitoring guidance**: Added note to prefer HTTP-API statistics over the `summary` command.
>   - **Formatting**: Normalized "Configuration Change." bolding and fixed code block fencing/newline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8e1b9c7da9aa562b396223d1ba27cfa7489e66f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->