### PR TITLE
TASK-160237: Momentum 5.2 release documentation

### DIFF
--- a/content/momentum/3/3-api/structs-ec-message.md
+++ b/content/momentum/3/3-api/structs-ec-message.md
@@ -118,6 +118,16 @@ struct _ec_message {
   /** @internal */
   const char *pathway;
   ec_message_resource_t *resources;
+
+  /** @since 4.3.2 */
+  /* set through ec_message_set_routing_domain, then
+     used in ec_message_get_routing_domain.
+     This field will not be written to spool */
+  string _routing_domain;
+
+  /** @since 5.2 */
+  /* TASK-115992: make sure an attempted IP can be logged in case of temp/perm failures */
+  address attempted_ip;
 };
 ```
 

--- a/content/momentum/3/3-api/structs-ec-message.md
+++ b/content/momentum/3/3-api/structs-ec-message.md
@@ -126,7 +126,7 @@ struct _ec_message {
   string _routing_domain;
 
   /** @since 5.2 */
-  /* TASK-115992: make sure an attempted IP can be logged in case of temp/perm failures */
+  /* Make sure an attempted IP can be logged in case of temp/perm failures */
   address attempted_ip;
 };
 ```

--- a/content/momentum/4/4-container-building.md
+++ b/content/momentum/4/4-container-building.md
@@ -1,5 +1,5 @@
 ---
-lastUpdated: "07/01/2025"
+lastUpdated: "01/31/2026"
 title: "Building an Image"
 description: "Instructions for building a Docker container image for Momentum."
 ---
@@ -20,13 +20,13 @@ RUN dnf update -y && \
     dnf clean all && rm -rf /var/cache/dnf
 
 # Copy and unpack the bundle into the container
-ARG version=5.0.0.xxxxx
+ARG version=M.m.p.bbbbb
 ADD momentum-mta-bundle-${version}.rhel9.x86_64.tar.gz /var/tmp/
 
 # Install as per the Momentum Installation Guide
 RUN cd /var/tmp/momentum-mta-${version} && \
     ./setrepodir && \
-    dnf install -y --config momentum.repo --enablerepo=momentum msys-role-mta msys-ecelerity-mobility msys-ecelerity-engagement-proxy && \
+    dnf install -y --config momentum.repo --enablerepo=momentum msys-role-mta && \
     dnf clean all && rm -rf /var/cache/dnf && \
     rm -rf /var/tmp/momentum-mta-bundle-${version}.rhel9.x86_64.tar.gz momentum-mta-${version}
 

--- a/content/momentum/4/4-lua-summary-table.md
+++ b/content/momentum/4/4-lua-summary-table.md
@@ -28,6 +28,7 @@ This section contains tables of Lua functions. Click the function name for detai
 | [msg.batch_id](/momentum/4/lua/ref-msg-batch-id) – Returns the human-readable ec_message.batch_id |   | msys.extended.message | 4.0 | data, data_spool, data_spool_each_rcpt, set_binding |
 | [msg.conn_id](/momentum/4/lua/ref-msg-conn-id) – Returns the human-readable ec_message.conn_id |   | msys.extended.message | 4.0 | data, data_spool, data_spool_each_rcpt, set_binding |
 | [msg.id](/momentum/4/lua/ref-msg-id) – Returns the human-readable ec_message.id |   | msys.extended.message | 4.0 | data, data_spool, data_spool_each_rcpt, set_binding |
+| [msg:attempted_ip](/momentum/4/lua/ref-attempted-ip) – Gets the IP address (if any) that was attempted for a failed outbound connection |   | msys.extended.message | 5.2 | core_log_delivery_v1, core_log_transient_failure_v1, core_log_permanent_failure_v1 |
 | [msg:binding](/momentum/4/lua/ref-msg-binding) – Sets the binding to the named binding, if one is provided | [value] | msys.extended.message | 4.0 | set_binding |
 | [msg:binding_group](/momentum/4/lua/ref-msg-binding-group) – Sets the binding_group to the named binding, if one is provided | [value] | msys.extended.message | 4.0 | set_binding |
 | [msg:body](/momentum/4/lua/ref-msg-body) – Set or get the message body (minus headers) | [...] | msys.extended.message | 4.0 | data, data_spool, data_spool_each_rcpt, set_binding |

--- a/content/momentum/4/config-options-summary.md
+++ b/content/momentum/4/config-options-summary.md
@@ -130,6 +130,7 @@ The `Version` column indicated the version(s) of Momentum that support the optio
 | [dns_expire_interval](/momentum/4/config/ref-dns-expire-interval) – How often to check for domains with expired DNS information | sending | 10 | 4.0 and later | global |
 | [dns_failures_to_purge](/momentum/4/config/ref-dns-failures-to-purge) – Configure the maximum number of DNS lookups | sending | 10 | 4.0 and later | domain, global |
 | [dns_fallback_to_tcp](/momentum/4/config/ref-dns-fallback-to-tcp) – Whether or not to fail over to TCP in place of UDP | both | false | 4.0 and later | global |
+| [dns_max_udp_queries_per_port](/momentum/4/config/ref-dns-max-udp-queries-per-port) - Limit the number of DNS queries sent using the same UDP source port | sending | 0 | 5.2 and later | global |
 | [domain](/momentum/4/config/ref-domain) *(scope)* – Configure domain-specific options | sending |   | 4.0 and later | binding, binding_group, global |
 | [domain_for_unqualified_recipient_addresses](/momentum/4/config/ref-domain-for-unqualified-recipient-addresses) – Configure a domain which will be used to resolve delivery for unqualified addresses | receiving |   | 4.0 and later | esmtp_listener, global, listen, pathway, pathway_group, peer |
 | [domain_for_unqualified_sender_address](/momentum/4/config/ref-domain-for-unqualified-sender-address) – Configure a domain which will be used to substitute for unqualified sender addresses | receiving |   | 4.0 and later | esmtp_listener, global, listen, pathway, pathway_group, peer |

--- a/content/momentum/4/config-options-summary.md
+++ b/content/momentum/4/config-options-summary.md
@@ -1,5 +1,5 @@
 ---
-lastUpdated: "09/20/2023"
+lastUpdated: "12/31/2025"
 title: "Configuration Options Summary"
 description: "This chapter lists all configuration options visible in the following scopes global domain host binding binding group security pathway pathway group listener listen peer threadpool debug flags and cluster as well as in the listener specific scope Module specific options are documented in the module documentation and options specific to..."
 ---
@@ -111,6 +111,8 @@ The `Version` column indicated the version(s) of Momentum that support the optio
 | [debug](/momentum/4/config/ref-debug-flags) – Set the debug level | na |   | 4.0 and later | debug_flags |
 | [debug_flags](/momentum/4/config/ref-debug-flags) *(scope)* – Configure debug verbosity | na |   | 4.0 and later | global |
 | [debug_level](/momentum/4/4-module-config) – Set the module debug level (applicable to all modules) (cluster-specific) | na | error | 4.0 and later | cluster |
+| [debug_throttle_max_num_same_message](/momentum/4/config/ref-debug-throttle) – Maximum number of identical debug messages to log within an interval | na | 0 | 5.2 and later | global |
+| [debug_throttle_period_secs](/momentum/4/config/ref-debug-throttle) – Time interval for debug message throttling, in seconds | na | 1 | 5.2 and later | global |
 | [default_binding](/momentum/4/config/ref-default-binding) – Control the default binding | sending | normal | 4.0 and later | global |
 | [default_charset](/momentum/4/config/ref-default-charset) – Control the character set | both | us-ascii | 4.0 and later | global, pathway, pathway_group |
 | [delay_dsn_max_retry_interval](/momentum/4/config/ref-delay-dsn-max-retry-interval) – Maximum interval for sending DSNs to the sender of a message that has not yet been delivered | sending | 43200 | 4.0 and later | binding, binding_group, domain, global |

--- a/content/momentum/4/config-options-summary.md
+++ b/content/momentum/4/config-options-summary.md
@@ -131,6 +131,8 @@ The `Version` column indicated the version(s) of Momentum that support the optio
 | [dns_failures_to_purge](/momentum/4/config/ref-dns-failures-to-purge) – Configure the maximum number of DNS lookups | sending | 10 | 4.0 and later | domain, global |
 | [dns_fallback_to_tcp](/momentum/4/config/ref-dns-fallback-to-tcp) – Whether or not to fail over to TCP in place of UDP | both | false | 4.0 and later | global |
 | [dns_max_udp_queries_per_port](/momentum/4/config/ref-dns-max-udp-queries-per-port) - Limit the number of DNS queries sent using the same UDP source port | sending | 0 | 5.2 and later | global |
+| [dns_udp_rcvbuf_size](/momentum/4/config/ref-dns-udp-buffer-size) - Set the size of the UDP socket receiving buffer used by DNS lookups | both | 0 | 5.2 and later | global |
+| [dns_udp_sndbuf_size](/momentum/4/config/ref-dns-udp-buffer-size) - Set the size of the UDP socket sending buffer used by DNS lookups | both | 0 | 5.2 and later | global |
 | [domain](/momentum/4/config/ref-domain) *(scope)* – Configure domain-specific options | sending |   | 4.0 and later | binding, binding_group, global |
 | [domain_for_unqualified_recipient_addresses](/momentum/4/config/ref-domain-for-unqualified-recipient-addresses) – Configure a domain which will be used to resolve delivery for unqualified addresses | receiving |   | 4.0 and later | esmtp_listener, global, listen, pathway, pathway_group, peer |
 | [domain_for_unqualified_sender_address](/momentum/4/config/ref-domain-for-unqualified-sender-address) – Configure a domain which will be used to substitute for unqualified sender addresses | receiving |   | 4.0 and later | esmtp_listener, global, listen, pathway, pathway_group, peer |

--- a/content/momentum/4/config/index.md
+++ b/content/momentum/4/config/index.md
@@ -66,6 +66,7 @@ description: "This chapter provides the definitions of the configuration options
 | [dns_expire_interval](/momentum/4/config/ref-dns-expire-interval) | how often to check for domains with expired DNS information |
 | [dns_failures_to_purge](/momentum/4/config/ref-dns-failures-to-purge) | configure the maximum number of DNS lookups |
 | [dns_fallback_to_tcp](/momentum/4/config/ref-dns-fallback-to-tcp) | whether or not to fail over to TCP in place of UDP |
+| [dns_max_udp_queries_per_port](/momentum/4/config/ref-dns-max-udp-queries-per-port) | limit the number of DNS queries sent using the same UDP source port |
 | [domain_for_unqualified_recipient_addresses](/momentum/4/config/ref-domain-for-unqualified-recipient-addresses) | configure a domain which will be used to resolve delivery for unqualified addresses |
 | [domain_for_unqualified_sender_address](/momentum/4/config/ref-domain-for-unqualified-sender-address) | configure a domain which will be used to substitute for unqualified sender addresses |
 | [domain](/momentum/4/config/ref-domain) | configure domain specific options |

--- a/content/momentum/4/config/index.md
+++ b/content/momentum/4/config/index.md
@@ -67,6 +67,8 @@ description: "This chapter provides the definitions of the configuration options
 | [dns_failures_to_purge](/momentum/4/config/ref-dns-failures-to-purge) | configure the maximum number of DNS lookups |
 | [dns_fallback_to_tcp](/momentum/4/config/ref-dns-fallback-to-tcp) | whether or not to fail over to TCP in place of UDP |
 | [dns_max_udp_queries_per_port](/momentum/4/config/ref-dns-max-udp-queries-per-port) | limit the number of DNS queries sent using the same UDP source port |
+| [dns_udp_rcvbuf_size](/momentum/4/config/ref-dns-udp-buffer-size) | set the size of the UDP socket receiving buffer used by DNS lookups |
+| [dns_udp_sndbuf_size](/momentum/4/config/ref-dns-udp-buffer-size) | set the size of the UDP socket sending buffer used by DNS lookups |
 | [domain_for_unqualified_recipient_addresses](/momentum/4/config/ref-domain-for-unqualified-recipient-addresses) | configure a domain which will be used to resolve delivery for unqualified addresses |
 | [domain_for_unqualified_sender_address](/momentum/4/config/ref-domain-for-unqualified-sender-address) | configure a domain which will be used to substitute for unqualified sender addresses |
 | [domain](/momentum/4/config/ref-domain) | configure domain specific options |

--- a/content/momentum/4/config/ref-debug-throttle.md
+++ b/content/momentum/4/config/ref-debug-throttle.md
@@ -1,0 +1,92 @@
+---
+lastUpdated: "12/31/2025"
+title: "Throttling Debug Messages"
+description: "Configure throttling to tell Momentum how to suppress repeated debug messages. When using the default logging module the messages will appear in the paniclog. The throttle is a decimal number representing the maximum number of repeated debug messages to log within a specified time interval"
+---
+
+When using the default logging module, debug messages will appear in the [paniclog](/momentum/4/log-formats-paniclog)
+depending on subsystem and level settings configured in [Debug_Flags](/momentum/4/config/ref-debug-flags). `Debug_Flags` is
+usually empty, so very few events are written to the `paniclog`. However, under certain circumstances, you need to get more
+information about some subsystem's behavior (e.g., SMTP), then by setting `Debug_Flags`, you can enable more verbose logging
+into `paniclog`. On the other hand, depending on the chosen level, `paniclog` may get populated with several lines of the same
+message, including some that might not be of your interest.
+
+Momentum’s debug throttling configuration allows you to suppress repeated debug messages. The throttle suppresses the logging
+of repeated messages beyond a specified limit during a time interval also specified. It is a global setting that applies to
+messages of all subsystems.
+
+> **NOTE:** Debug throttling global configuration **DOES NOT** apply to messages logged at the `CRITICAL`, `ERROR`, or
+> `WARNING` levels of any subsystem, due to their relevance for operation and diagnosis.
+
+It is important to note that debug throttling is applied not necessarily to *identical* messages, but to messages that are
+considered the same after removing variable parts such as timestamps, IP addresses, or other dynamic content. In other words,
+if the source of the message is something like this:
+
+```
+<timestamp> Message received from: <mailfrom>
+```
+
+then all messages that match this pattern will be considered the same for throttling purposes, regardless of the actual
+values of `<timestamp>` and `<mailfrom>`. This happens because the default logging module is based on `printf`-style
+format strings, which allows variable content in log messages, and it is the format string that determines message sameness.
+
+> __**_WARNING:_**__ Be cautious when enabling debug throttling, as it may cause some performance overhead due to the additional
+> processing required to track and suppress repeated messages.
+
+<a name="conf.ref.debug_throttle"></a>
+# Configuration options
+
+Debug throttling is configured using the following options in the global scope of your `ecelerity.conf` file:
+- **debug_throttle_max_num_same_message**
+- **debug_throttle_period_secs**
+
+<a name="conf.ref.debug_throttle_max_num_same_message"></a> 
+## Maximum number of the same message
+
+<a name="conf.ref.debug_throttle_max_num_same_message.name"></a> 
+### Name
+
+`debug_throttle_max_num_same_message`
+
+<a name="conf.ref.debug_throttle_max_num_same_message.description"></a> 
+### Description
+
+Sets the maximum number of repeated debug messages to log within a specified time interval. The default is `0`, which means no
+throttling is applied to the logging of repeated debug messages.
+
+<a name="conf.ref.debug_throttle_period_secs.example"></a>
+### Example
+
+```
+debug_throttle_max_num_same_message = 5
+```
+
+With this configuration, only five lines of the same debug message will be logged during the time interval specified by
+`debug_throttle_period_secs`.
+
+<a name="conf.ref.debug_throttle_period_secs"></a> 
+## Time interval of throttling
+
+<a name="conf.ref.debug_throttle_period_secs.name"></a> 
+### Name
+`debug_throttle_period_secs`
+
+<a name="conf.ref.debug_throttle_period_secs.description"></a>
+### Description
+
+Sets the time interval in seconds during which repeated debug messages are counted for throttling purposes. The default is
+`1` second, with a maximum of `60` seconds.
+
+<a name="conf.ref.debug_throttle_period_secs.example"></a>
+### Example
+```
+debug_throttle_period_secs = 30
+```
+With this configuration, the time interval for counting repeated debug messages is set to 30 seconds. Combined with the
+previous example for `debug_throttle_max_num_same_message`, only five lines of the same debug message will be logged every
+30 seconds.
+
+<a name="conf.ref.debug_throttle.scope"></a> 
+# Scope
+
+Debug throttling options are valid in the global scope.

--- a/content/momentum/4/config/ref-debug-throttle.md
+++ b/content/momentum/4/config/ref-debug-throttle.md
@@ -61,8 +61,8 @@ throttling is applied to the logging of repeated debug messages.
 debug_throttle_max_num_same_message = 5
 ```
 
-With this configuration, only five lines of the same debug message will be logged during the time interval specified by
-`debug_throttle_period_secs`.
+With this configuration, if the same debug message occurs 20 times within the time interval specified by `debug_throttle_period_secs`,
+only the first 5 instances will be logged. The remaining 15 messages are suppressed.
 
 <a name="conf.ref.debug_throttle_period_secs"></a> 
 ## Time interval of throttling
@@ -74,8 +74,8 @@ With this configuration, only five lines of the same debug message will be logge
 <a name="conf.ref.debug_throttle_period_secs.description"></a>
 ### Description
 
-Sets the time interval in seconds during which repeated debug messages are counted for throttling purposes. The default is
-`1` second, with a maximum of `60` seconds.
+Sets the time interval in seconds during which repeated debug messages are counted for throttling purposes.
+The counters are reset when starting a new interval. The default is `1` second, with a maximum of `60` seconds.
 
 <a name="conf.ref.debug_throttle_period_secs.example"></a>
 ### Example
@@ -83,8 +83,8 @@ Sets the time interval in seconds during which repeated debug messages are count
 debug_throttle_period_secs = 30
 ```
 With this configuration, the time interval for counting repeated debug messages is set to 30 seconds. Combined with the
-previous example for `debug_throttle_max_num_same_message`, only five lines of the same debug message will be logged every
-30 seconds.
+previous example for `debug_throttle_max_num_same_message`, up to 5 lines of the same debug message will be logged every
+30 seconds. After that, the counter resets and other 5 instances can be logged during the next 30-second window.
 
 <a name="conf.ref.debug_throttle.scope"></a> 
 # Scope

--- a/content/momentum/4/config/ref-dns-max-udp-queries-per-port.md
+++ b/content/momentum/4/config/ref-dns-max-udp-queries-per-port.md
@@ -1,0 +1,26 @@
+---
+lastUpdated: "01/31/2026"
+title: "dns_max_udp_queries_per_port"
+description: "dns max udp queries per port limit the number of DNS queries sent using the same UDP source port Momentum uses User Datagram Protocol UDP for DNS queries However the size of a UDP packet is limited and a DNS query can exceed it Set this option to..."
+---
+
+<a name="conf.ref.dns_max_udp_queries_per_port"></a> 
+## Name
+
+dns_max_udp_queries_per_port — limit the number of DNS queries sent using the same UDP source port
+
+## Synopsis
+
+`dns_max_udp_queries_per_port = 10`
+
+<a name="idp69432014"></a> 
+## Description
+
+Momentum uses User Datagram Protocol (UDP) for DNS queries. Each internal channel to the DNS server(s) is assigned a dynamic (ephemeral) UDP source port number. All DNS queries sent over that channel use the same source port. When many queries originate from a single source port, security devices such as firewalls may interpret this pattern as malicious behavior (e.g., a DNS-based attack) and drop or block the queries. This setting limits how many DNS queries will be sent from each source port before Momentum allocates a new port number, helping to avoid triggering such security measures.
+
+The default value is `0` (no limit). Most users do not need to change this value unless experiencing DNS-related firewall blocks.
+
+<a name="idp69432015"></a> 
+## Scope
+
+`dns_max_udp_queries_per_port` is valid in the global scope.

--- a/content/momentum/4/config/ref-dns-udp-buffer-size.md
+++ b/content/momentum/4/config/ref-dns-udp-buffer-size.md
@@ -1,0 +1,30 @@
+---
+lastUpdated: "01/31/2026"
+title: "dns_udp_rcvbuf_size, dns_udp_sndbuf_size"
+description: "dns_udp_***buf_size set the size of the UDP socket buffers used by DNS lookups"
+---
+
+<a name="conf.ref.dns_udp_buffer_size"></a> 
+## Name
+
+dns_udp_rcvbuf_size — set the size of the UDP socket receiving buffer used by DNS lookups
+
+dns_udp_sndbuf_size - set the size of the UDP socket sending buffer
+
+## Synopsis
+
+`dns_udp_rcvbuf_size = 65536`
+
+`dns_udp_sndbuf_size = 16384`
+
+<a name="idp69437158"></a> 
+## Description
+
+By default, Momentum uses the operating system's default buffer sizes for the UDP sockets used for DNS lookups. In high-volume environments with tens of thousands of domains, these default buffer sizes may be insufficient. When the receive buffer fills up, incoming DNS responses can be dropped, causing unnecessary DNS failures and retries that further increase query volume. These configuration options allow you to increase the DNS socket buffer sizes at startup.
+
+The default value for both options is `0` (use OS defaults).
+
+<a name="idp69437159"></a> 
+## Scope
+
+Both `dns_udp_rcvbuf_size` and `dns_udp_sndbuf_size` are valid in the global scope.

--- a/content/momentum/4/console-commands/summary-reset.md
+++ b/content/momentum/4/console-commands/summary-reset.md
@@ -21,7 +21,9 @@ summary reset — reset summary statistics
 statistics cleared.
 ```
 
-The **summary reset**       command resets the statistics counters of the running instance. It is useful for determining the current performance levels of a long-running Momentum instance, particularly with respect to metrics that are averages, such as Delivery Rate and Reception Rate.
+The **summary reset** command resets the statistics counters of the running instance. It is useful for determining the current performance levels of a long-running Momentum instance, particularly with respect to metrics that are averages, such as Delivery Rate and Reception Rate.
+
+**NOTE:** Since Momentum 5.2, reset of statistics is available through the HTTP API as well. See the [summary](/momentum/4/http-api-stats/summary) documentation for details.
 
 <a name="idp10810640"></a> 
 ## See Also

--- a/content/momentum/4/eol-policy.md
+++ b/content/momentum/4/eol-policy.md
@@ -64,7 +64,8 @@ Momentum version 5 became GA on March 1, 2025. Therefore:
 | Momentum 4.7.0                  | 2023/12/19 | 2025/10/17         | 2027/3/1       |
 | Momentum 4.8.0                  | 2024/10/17 | 2026/3/1           | 2027/3/1       |
 | Momentum 5.0.0                  | 2025/3/1   | 2026/7/1           | TBD            |
-| **Momentum 5.1.0**              | 2025/7/1   | TBD                | TBD            |
+| Momentum 5.1.0                  | 2025/7/1   | 2027/1/31          | TBD            |
+| **Momentum 5.2.0**              | 2026/1/31  | TBD                | TBD            |
 
 > ¹ Momentum 4.4.x was superseded by 4.6, which was the last version supporting CentOS 7.
 >

--- a/content/momentum/4/http-api-stats/summary.md
+++ b/content/momentum/4/http-api-stats/summary.md
@@ -1,5 +1,5 @@
 ---
-lastUpdated: "11/05/2024"
+lastUpdated: "12/31/2025"
 title: "Summary"
 description: "stats summary show global metrics Perhaps the most common API command stats summary will produce global metrics such as queue sizes message counts and throughput rates since startup or the last reset of statistics"
 ---
@@ -7,15 +7,19 @@ description: "stats summary show global metrics Perhaps the most common API comm
 <a name="http_api_stats.summary"></a>
 ## Name
 
-`/stats/summary` — show global metrics
+`/stats/summary` — global metrics
 
 ## Synopsis
 
 `GET /stats/summary`
 
+`DELETE /stats/summary`
+
 ## Description
 
-Perhaps the most common API command, `/stats/summary` will produce global metrics such as queue sizes, message counts and throughput rates since startup or the last reset of statistics.
+### Gather Global Metrics
+
+Perhaps the most common API command, `GET /stats/summary` will produce global metrics such as queue sizes, message counts and throughput rates since startup or the last reset of statistics.
 
 The data is formatted as a JSON object and you might want to use the `curl` command to do the request (e.g. `curl -sS localhost:2081/stats/summary`).
 
@@ -323,10 +327,23 @@ The number of seconds that Momentum has been running continuously.
 
 </dl>
 
+### Reset Statistics
+
+You can reset the statistics used to generate this report by issuing a `DELETE` request to the same URL: `DELETE /stats/summary`. This will reset all the cumulative counters to zero and the time-based metrics will be calculated from that point forward. The output of a successful reset operation is as follows:
+
+```json
+{
+  "message": "statistics cleared"
+}
+```
+
 ## See Also
 
+[summary](/momentum/4/console-commands/summary),
 [summary reset](/momentum/4/console-commands/summary-reset)
 
 ## Note
 
-This command was first implemented in Momentum 4.4.1.
+`GET /stats/summary` was first implemented in Momentum 4.4.1.
+
+`DELETE /stats/summary` was first implemented in Momentum 5.2.

--- a/content/momentum/4/http-api-stats/summary.md
+++ b/content/momentum/4/http-api-stats/summary.md
@@ -17,6 +17,7 @@ description: "stats summary show global metrics Perhaps the most common API comm
 
 ## Description
 
+<a name="http_api_stats.summary.get"></a>
 ### Gather Global Metrics
 
 Perhaps the most common API command, `GET /stats/summary` will produce global metrics such as queue sizes, message counts and throughput rates since startup or the last reset of statistics.
@@ -327,6 +328,7 @@ The number of seconds that Momentum has been running continuously.
 
 </dl>
 
+<a name="http_api_stats.summary.delete"></a>
 ### Reset Statistics
 
 You can reset the statistics used to generate this report by issuing a `DELETE` request to the same URL: `DELETE /stats/summary`. This will reset all the cumulative counters to zero and the time-based metrics will be calculated from that point forward. The output of a successful reset operation is as follows:

--- a/content/momentum/4/lua/index.md
+++ b/content/momentum/4/lua/index.md
@@ -87,6 +87,7 @@ description: "This section details all Lua functions Functions are ordered alpha
 | [msg.conn_id](/momentum/4/lua/ref-msg-conn-id) | Return the human-readable ec_message.conn_id |
 | [msg.id](/momentum/4/lua/ref-msg-id) | Return the human-readable ec_message.id |
 | [msg:address_header](/momentum/4/lua/ref-msg-address-header) | Returns address components as an array |
+| [msg:attempted_ip](/momentum/4/lua/ref-msg-attempted-ip) | Gets the attempted IP address for a failed outbound connection |
 | [msg:binding](/momentum/4/lua/ref-msg-binding) | Set or get the message binding |
 | [msg:binding_group](/momentum/4/lua/ref-msg-binding-group) | Sets the binding_group to the named binding, if one is provided. |
 | [msg:body](/momentum/4/lua/ref-msg-body) | Set the message body (minus headers) if provided |

--- a/content/momentum/4/lua/ref-msg-attempted-ip.md
+++ b/content/momentum/4/lua/ref-msg-attempted-ip.md
@@ -1,0 +1,37 @@
+---
+lastUpdated: "01/31/2026"
+title: "msg:attempted_ip"
+description: "msg attempted_ip Gets the IP address (if any) that was attempted for a failed outbound connection"
+---
+
+<a name="lua.ref.msg_attempted_ip"></a> 
+## Name
+
+msg:attempted_ip — Gets the IP address (if any) that was attempted for a failed outbound connection.
+
+> This function was introduced in Momentum 5.2.
+
+<a name="idp69519529"></a> 
+## Synopsis
+
+`msg:attempted_ip()`
+
+<a name="idp69519530"></a> 
+## Description
+
+For successful mail deliveries, connection details are available through the connection handle (`conn_handle`) in the message object (`ec_message`). However, when a connection fails, the handle is null. The `attempted_ip` field in the message object can be checked for the IP address that Momentum attempted to connect to. This is useful for logging connection attempts and troubleshooting delivery issues. The `attempted_ip()` function returns `nil` if the IP address is unknown.
+
+<a name="lua.ref.msg_attempted_ip.example"></a> 
+
+```
+require("msys.core")
+require("msys.extended.message")
+
+local mod = {}
+
+function mod:core_log_transient_failure_v1(msg, dr, now, note, note_len)
+  print(tostring(msg.id) .. ": failed to connect to mail server using the IP address " .. tostring(msg:attempted_ip()))
+end
+
+msys.registerModule("example", mod)
+```

--- a/content/momentum/4/modules/clamav.md
+++ b/content/momentum/4/modules/clamav.md
@@ -1,12 +1,14 @@
 ---
-lastUpdated: "03/26/2020"
+lastUpdated: "12/31/2025"
 title: "clamav – ClamAV"
 description: "The clamav module is an open source antivirus engine that is part of the default Momentum installation The following is an example configuration Example 71 28 clamav Configuration In order to use this module you must install Clam AV on your server and update it as needed or desired Configure..."
 ---
 
 <a name="idp20200832"></a> 
 
-The clamav module is an open source antivirus engine that is part of the default Momentum installation.
+The clamav module allows integration with the open source ClamAV antivirus engine.
+
+> **NOTE:** Since version 5.2, the `msys-clamav` package, which contained the ClamAV engine, is no longer shipped with the Momentum installation bundle. To use this clamav module, the engine must be installed using the general available ClamAV packages (e.g., `clamav` and `clamd` RPMs), then configured and maintained separately by following the official ClamAV [documentation](https://docs.clamav.net/).
 
 ### <a name="idp20203168"></a> Configuration
 

--- a/content/momentum/4/modules/dnsbuf.md
+++ b/content/momentum/4/modules/dnsbuf.md
@@ -8,7 +8,7 @@ description: "Configuration Change This feature is available in Momentum 4 2 and
 
 **Configuration Change.** This feature is available from Momentum 4.2 through 4.7.
 
-> **NOTE: This feature was DEPRECATED in Momentum 4.8 and is no longer supported.**
+> **NOTE: This feature was DEPRECATED in Momentum 4.8 and is no longer supported. Please refer to [here](/momentum/4/config/ref-dns-udp-buffer-size) for alternative configuration options.**
 
 Momentum does not manipulate the size of UDP sockets it creates and uses for DNS queries; instead, it will use the default sizes configured by the Operating System. This can create problems for clients with too many domains (e.g., tens of thousands) in the system. Responses may be dropped, causing unnecessary DNS failures and retries, thus further increasing the DNS query volume. The `dnsbuf` module enables the client to manipulate the DNS buffer sizes on demand, on the fly.
 

--- a/content/momentum/changelog/5/5-2.md
+++ b/content/momentum/changelog/5/5-2.md
@@ -25,3 +25,4 @@ This section will list all of the major changes that happened with the release o
 | Fix | TASK-115806 | Fixed an issue with an empty TXT answer for MTA-STS |
 | Fix | TASK-145503 | Fixed the SPF module to observe the maximum number of DNS queries for a lookup ([RFC 7208 4.6.4](https://datatracker.ietf.org/doc/html/rfc7208#section-4.6.4)) |
 | Fix | TASK-175798 | Requeue a message on RSET upon a configuration change |
+| Fix | TASK-188399 | Fixed an issue with `dns_cache lookup` output that printed only the first IP of a DNS A query |

--- a/content/momentum/changelog/5/5-2.md
+++ b/content/momentum/changelog/5/5-2.md
@@ -11,9 +11,9 @@ This section will list all of the major changes that happened with the release o
 | Type | Ticket | Description |
 | --- | --- | --- |
 | Feature | | Support for Red Hat Enterprise Linux 10, for Intel (`x86_64`) and ARM (`aarch64`) platforms |
-| Feature | | TLS v1.3 support for SMTP using GnuTLS |
+| Feature | | Added TLS v1.3 support for SMTP using GnuTLS |
 | Feature | | Added support for [throttling](/momentum/4/config/ref-debug-throttle) of duplicated `paniclog` messages, to reduce log volume and improve diagnostics |
-| Feature | | Added request for global metrics (summary) reset to [HTTP API](/momentum/4/http-api-stats/summary) |
+| Feature | | Allows global metrics (summary) reset using [HTTP API](/momentum/4/http-api-stats/summary) |
 | Feature | | New DNS configuration options to [set UDP buffer sizes](/momentum/4/config/ref-dns-udp-buffer-size) |
 | Feature | | New DNS configuration option to [limit reuse](/momentum/4/config/ref-dns-max-udp-queries-per-port) of dynamic source ports by queries |
 | Feature | | New [attempted_ip](/momentum/4/lua/ref-msg-attempted-ip) field in the [ec_message](/momentum/3/3-api/structs-ec-message) object, for better visibility into IP addresses used in failed delivery attempts |

--- a/content/momentum/changelog/5/5-2.md
+++ b/content/momentum/changelog/5/5-2.md
@@ -1,0 +1,27 @@
+---
+lastUpdated: "01/31/2026"
+title: "Momentum 5.2 Changelog"
+description: "Momentum 5.2 was released on 2026-01-31. This section will list all of the major changes that happened with the release of Momentum 5.2. Depending on installation type, all changes may not be applicable"
+---
+
+This section will list all of the major changes that happened with the release of **Momentum 5.2**. Depending on installation type, all changes may not be applicable
+
+<a name="changelog.5.2.table"></a>
+
+| Type | Ticket | Description |
+| --- | --- | --- |
+| Feature | | Support for Red Hat Enterprise Linux 10, for Intel (`x86_64`) and ARM (`aarch64`) platforms |
+| Feature | | TLS v1.3 support for SMTP using GnuTLS |
+| Feature | | Added support for [throttling](/momentum/4/config/ref-debug-throttle) of duplicated `paniclog` messages, to reduce log volume and improve diagnostics |
+| Feature | | Added request for global metrics (summary) reset to [HTTP API](/momentum/4/http-api-stats/summary) |
+| Feature | | New DNS configuration options to [set UDP buffer sizes](/momentum/4/config/ref-dns-udp-buffer-size) |
+| Feature | | New DNS configuration option to [limit reuse](/momentum/4/config/ref-dns-max-udp-queries-per-port) of dynamic source ports by queries |
+| Feature | | New [attempted_ip](/momentum/4/lua/ref-msg-attempted-ip) field in the [ec_message](/momentum/3/3-api/structs-ec-message) object, for better visibility into IP addresses used in failed delivery attempts |
+| Feature | | New `injection_time_ms` field in the message events, for improved precision in diagnostics |
+| Feature | | Updated major version of NodeJS LTS (now 22.22.0) |
+| Feature | | Removed `msys-pg` (PostgreSQL server) and `msys-clamav` (ClamAV antivirus) RPMs from the Momentum bundle, to be replaced with their 3rd-party packages |
+| Fix | TASK-87814  | Changed the SPF module to avoid including expanded macros in the cache |
+| Fix | TASK-109720 | Fixed the DNS resolution of an MX whose answer contains multiple CNAME records |
+| Fix | TASK-115806 | Fixed an issue with an empty TXT answer for MTA-STS |
+| Fix | TASK-145503 | Fixed the SPF module to observe the maximum number of DNS queries for a lookup ([RFC 7208 4.6.4](https://datatracker.ietf.org/doc/html/rfc7208#section-4.6.4)) |
+| Fix | TASK-175798 | Requeue a message on RSET upon a configuration change |

--- a/content/momentum/changelog/5/5-2.md
+++ b/content/momentum/changelog/5/5-2.md
@@ -24,5 +24,5 @@ This section will list all of the major changes that happened with the release o
 | Fix | TASK-109720 | Fixed the DNS resolution of an MX whose answer contains multiple CNAME records |
 | Fix | TASK-115806 | Fixed an issue with an empty TXT answer for MTA-STS |
 | Fix | TASK-145503 | Fixed the SPF module to observe the maximum number of DNS queries for a lookup ([RFC 7208 4.6.4](https://datatracker.ietf.org/doc/html/rfc7208#section-4.6.4)) |
-| Fix | TASK-175798 | Requeue a message on RSET upon a configuration change |
+| Fix | TASK-175798 | Requeue a message on connection RSET upon a configuration change |
 | Fix | TASK-188399 | Fixed an issue with `dns_cache lookup` output that printed only the first IP of a DNS A query |

--- a/content/momentum/changelog/5/index.md
+++ b/content/momentum/changelog/5/index.md
@@ -8,3 +8,4 @@ description: "Momentum 5.x Changelogs"
 
 * [Momentum 5.0 Changelogs](/momentum/changelog/5/5-0)
 * [Momentum 5.1 Changelogs](/momentum/changelog/5/5-1)
+* [Momentum 5.1 Changelogs](/momentum/changelog/5/5-2)

--- a/content/momentum/changelog/5/index.md
+++ b/content/momentum/changelog/5/index.md
@@ -8,4 +8,4 @@ description: "Momentum 5.x Changelogs"
 
 * [Momentum 5.0 Changelogs](/momentum/changelog/5/5-0)
 * [Momentum 5.1 Changelogs](/momentum/changelog/5/5-1)
-* [Momentum 5.1 Changelogs](/momentum/changelog/5/5-2)
+* [Momentum 5.2 Changelogs](/momentum/changelog/5/5-2)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates that add new reference pages and minor clarifications; low risk aside from potential user confusion if any option/endpoint details are inaccurate.
> 
> **Overview**
> Adds Momentum **5.2** release documentation, including a new `5.2` changelog entry and updated EOL table.
> 
> Documents new/updated capabilities: debug message throttling config (`debug_throttle_*`), DNS UDP tuning (`dns_udp_*buf_size`) and port reuse limiting (`dns_max_udp_queries_per_port`), HTTP API support for `DELETE /stats/summary` to reset statistics (and cross-links from `summary reset`), and a new Lua accessor `msg:attempted_ip()` backed by an `ec_message.attempted_ip` field.
> 
> Also refreshes container build guidance (version placeholder and simplified package install) and clarifies ClamAV packaging changes (Momentum no longer ships `msys-clamav`, requiring OS-provided ClamAV).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7c80aa771888ee9a6fb00a17d05da1b77734c13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->