### PR TITLE
remove CAA mention in managed https doc

### DIFF
--- a/content/docs/tech-resources/managed-https-for-tracking-domains.md
+++ b/content/docs/tech-resources/managed-https-for-tracking-domains.md
@@ -190,8 +190,8 @@ If your certificate remains in Pending status for more than 30 minutes:
 
 1. Verify the CNAME record points to the correct SparkPost [V2 endpoint](#tracking-endpoints)
 2. Confirm the tracking domain is verified
-4. Ensure DNS has fully propagated
-5. Contact support if the issue persists
+3. Ensure DNS has fully propagated
+4. Contact support if the issue persists
 
 ### Certificate status shows _Failed_
 

--- a/content/docs/tech-resources/managed-https-for-tracking-domains.md
+++ b/content/docs/tech-resources/managed-https-for-tracking-domains.md
@@ -190,7 +190,6 @@ If your certificate remains in Pending status for more than 30 minutes:
 
 1. Verify the CNAME record points to the correct SparkPost [V2 endpoint](#tracking-endpoints)
 2. Confirm the tracking domain is verified
-3. Check for CAA records blocking Let's Encrypt
 4. Ensure DNS has fully propagated
 5. Contact support if the issue persists
 


### PR DESCRIPTION
CAA verification step is not necessary during troubleshooting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that narrows troubleshooting steps; no product or runtime behavior is affected.
> 
> **Overview**
> Updates the managed HTTPS troubleshooting guidance by **removing the suggestion to check CAA records** when a certificate is stuck in `Pending`, leaving only DNS propagation and support escalation steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 405c508e6132596713beb6a603d07ca2f554b8f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->