### PR TITLE
Webhooks mTLS documentation

### DIFF
--- a/content/docs/tech-resources/webhook-authentication.md
+++ b/content/docs/tech-resources/webhook-authentication.md
@@ -1,7 +1,7 @@
 ---
 lastUpdated: "10/01/2021"
 title: "Event Webhook Authentication and Security"
-description: "Spark Post offers optional but highly recommended security measures that can be implemented when setting up a webhook namely, SSL, OAuth 2.0, mTLS, and Basic Authentication These measures increase the security of your webhook event data and ensure that the data delivered originates from Spark Post OAuth 2..."
+description: "Spark Post offers optional but highly recommended security measures that can be implemented when setting up a webhook namely, SSL, OAuth 2.0, and Basic Authentication These measures increase the security of your webhook event data and ensure that the data delivered originates from Spark Post OAuth 2..."
 ---
 
 SparkPost [Event Webhooks](https://developers.sparkpost.com/api/webhooks/) offers some optional (but highly recommended) security measures that can be implemented when setting up a webhook. These measures increase the security of your webhook event data and ensure that the data delivered originates from SparkPost.
@@ -11,9 +11,6 @@ SparkPost [Event Webhooks](https://developers.sparkpost.com/api/webhooks/) offer
 **SSL (TLS)**
 
 Secure Socket Layer (SSL), also known as Transport Layer Security (TLS), are cryptographic protocols that provide communications security over a computer network.  If your Target endpoint supports SSL then you can prefix your endpoint URL with "https://".  The default port is 443, in which case you do not need to specify the port in the URL e.g. https://yourdomain.com/yourendpoint.  If your Target endpoint has SSL enabled on a different port then you may specifcy it in your URL.  E.g. "https://yourdomain.com:81/yourendpoint"
-
-**mTLS**
-Event webhooks supports [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) for transport layer authentication. mTLS is not a separate authentication schema, it is simply a change in how the TLS connection handshake happens.  SparkPost = CLIENT, your app = SERVER.
 
 **IP Whitelisting**
 For those customers that require inbound traffic to be whitelisted in a firewall we do maintain the hostname wh.egress.sparkpost.com which lists the egress IPs under the host’s A record. Please let your TAM know that you are whitelisting IPs and SparkPost will notify you if this list changes, with some advance notice.


### PR DESCRIPTION
DOCS: Remove mTLS mention from webhook authentication documentation

### What Changed

This PR removes all mentions of mTLS (mutual TLS) from the Event Webhook Authentication and Security documentation (`content/docs/tech-resources/webhook-authentication.md`).

Specifically:
*   Removed "mTLS," from the frontmatter description.
*   Removed the dedicated "mTLS" section, including its heading and explanatory paragraph, from the "Webhook Network Security" section.

This change reflects the deprecation of mTLS support for webhooks due to industry-wide changes where Certificate Authorities will no longer include Client Authentication capabilities in publicly trusted certificates. The documentation now accurately reflects supported security measures (SSL/TLS, OAuth 2.0, and Basic Authentication).

### How To Test or Verify

1.  Review the `content/docs/tech-resources/webhook-authentication.md` file in this PR.
2.  Verify that "mTLS" is no longer present in the frontmatter description.
3.  Confirm that the entire "mTLS" section under "Webhook Network Security" has been removed.
4.  If a Netlify deploy preview is available, check the rendered page for "Event Webhook Authentication and Security" to ensure no mention of mTLS remains.

### PR Checklist

#### All PRs Checklist

- [x] Give your pull request a meaningful name.
- [x] Use lowercase filenames.
- [ ] Apply at least one team label according to which team is the content expert (ie. `team-FE` or `team-SAZ`)
- [ ] Pull request approval from the FE team or content experts (see label applied above) that isn't the content creator.

#### Content Changes Checklist

- [ ] Check that your article looks correct in the preview here or in a [Netlify deploy preview](https://app.netlify.com/sites/support-docs/deploys).
- [ ] Check the links in your article.
- [ ] Check the images in your article (if there are any)
- [ ] Check to make sure you are using markdown appropriately as outlined in `examples/article.md` in the root of the project directory and on the momentum doc's [preface article](https://support.sparkpost.com/momentum/4/4-preface)
- [ ] Check to make sure the [Copy and Tone Guidelines are followed](https://docs.google.com/document/d/1dej9J7N9M8lcbJXnT9kxyNB_EFBPHIBLZBbHaxRWqhQ/edit).

---
[Slack Thread](https://messagebird.slack.com/archives/C092VLKDAL8/p1770919135447479?thread_ts=1770919135.447479&cid=C092VLKDAL8)

<p><a href="https://cursor.com/background-agent?bcId=bc-84ee5617-01f0-54a7-9ceb-c6bcc510f4d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-84ee5617-01f0-54a7-9ceb-c6bcc510f4d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that removes an unsupported security option; no runtime or API behavior is affected.
> 
> **Overview**
> Updates the Event Webhook Authentication docs to **remove mTLS guidance**. The frontmatter description and the “Webhook Network Security” section no longer mention or describe mTLS, leaving SSL/TLS, IP whitelisting, Basic Auth, and OAuth 2.0 as the documented options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af364e30124874ae70d58805aa6131a91c9e998d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->