### PR TITLE
docs: mark mTLS as deprecating for event webhooks

### DIFF
--- a/content/docs/tech-resources/webhook-authentication.md
+++ b/content/docs/tech-resources/webhook-authentication.md
@@ -1,7 +1,7 @@
 ---
 lastUpdated: "10/01/2021"
 title: "Event Webhook Authentication and Security"
-description: "Spark Post offers optional but highly recommended security measures that can be implemented when setting up a webhook namely, SSL, OAuth 2.0, mTLS, and Basic Authentication These measures increase the security of your webhook event data and ensure that the data delivered originates from Spark Post OAuth 2..."
+description: "Spark Post offers optional but highly recommended security measures that can be implemented when setting up a webhook namely, SSL, OAuth 2.0, mTLS (deprecating), and Basic Authentication These measures increase the security of your webhook event data and ensure that the data delivered originates from Spark Post OAuth 2..."
 ---
 
 SparkPost [Event Webhooks](https://developers.sparkpost.com/api/webhooks/) offers some optional (but highly recommended) security measures that can be implemented when setting up a webhook. These measures increase the security of your webhook event data and ensure that the data delivered originates from SparkPost.
@@ -12,8 +12,8 @@ SparkPost [Event Webhooks](https://developers.sparkpost.com/api/webhooks/) offer
 
 Secure Socket Layer (SSL), also known as Transport Layer Security (TLS), are cryptographic protocols that provide communications security over a computer network.  If your Target endpoint supports SSL then you can prefix your endpoint URL with "https://".  The default port is 443, in which case you do not need to specify the port in the URL e.g. https://yourdomain.com/yourendpoint.  If your Target endpoint has SSL enabled on a different port then you may specifcy it in your URL.  E.g. "https://yourdomain.com:81/yourendpoint"
 
-**mTLS**
-Event webhooks supports [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) for transport layer authentication. mTLS is not a separate authentication schema, it is simply a change in how the TLS connection handshake happens.  SparkPost = CLIENT, your app = SERVER.
+**mTLS (deprecating)**
+Event webhooks [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) support for transport layer authentication is in route to deprecation on all regions at May 18th, 2026. mTLS is not a separate authentication schema, it is simply a change in how the TLS connection handshake happens.  SparkPost = CLIENT, your app = SERVER.
 
 **IP Whitelisting**
 For those customers that require inbound traffic to be whitelisted in a firewall we do maintain the hostname wh.egress.sparkpost.com which lists the egress IPs under the host’s A record. Please let your TAM know that you are whitelisting IPs and SparkPost will notify you if this list changes, with some advance notice.


### PR DESCRIPTION
## Summary
- Mark mTLS support for event webhooks as in route to deprecation on all regions at May 18th, 2026
- Update the page description frontmatter to reflect the deprecation

## Test plan
- [ ] Verify the webhook authentication docs page renders correctly
- [ ] Confirm mTLS deprecation notice and date are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates wording about mTLS support; no runtime or API behavior changes.
> 
> **Overview**
> Updates the event webhook authentication docs to **mark mTLS as deprecating**, including adding a deprecation notice with an explicit end date (May 18, 2026).
> 
> Adjusts the page frontmatter `description` and the `mTLS` section heading/text to reflect the deprecation status.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db68e77752f2fdd279d4b84d2500ea605a1e0dc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->