### PR TITLE
Doc: new FIPS 140-3 compliant license signing (SparkPost/Momentum#1064)

### DIFF
--- a/content/momentum/4/before-you-begin.md
+++ b/content/momentum/4/before-you-begin.md
@@ -1,5 +1,5 @@
 ---
-lastUpdated: "03/26/2020"
+lastUpdated: "05/19/2026"
 title: "Before You Begin"
 description: "This chapter describes issues that need to be considered or addressed prior to preparing for the installation on Analytics and or Platform MTA nodes For each of your servers that run the MTA you will need a license file in this directory opt msys ecelerity etc You will need to..."
 ---
@@ -12,6 +12,12 @@ This chapter describes issues that need to be considered or addressed prior to p
 For each of your servers that run the MTA you will need a `license` file in this directory: `/opt/msys/ecelerity/etc/`
 
 You will need to provide Message Systems with a MAC address for each MTA node in your deployment. Be sure that your nodes have access to the Internet over port 80 so that you can download the license.
+
+### Note
+
+Starting with Momentum 5.3.0, licenses issued by Message Systems are signed with ECDSA P-256 / SHA-256 ([FIPS 186-4](https://csrc.nist.gov/pubs/fips/186-4/final)). A re-issued license in this format is required only on deployments that **enforce** FIPS 140-3 at the crypto-library level — for example, when running against SafeLogic CryptoComply (a FIPS 140-3 validated drop-in for OpenSSL), or against OpenSSL 3.x configured with `default_properties = fips=yes`. In those configurations the DSA-2048 / SHA-1 verify path is rejected as non-compliant and the MTA reports the license as invalid.
+
+Existing DSA-2048 / SHA-1 licenses continue to validate on all other deployments, including OpenSSL 3.x with the FIPS provider merely loaded (without `default_properties = fips=yes`).
 
 ### Note
 

--- a/content/momentum/changelog/5/5-3-0.md
+++ b/content/momentum/changelog/5/5-3-0.md
@@ -10,4 +10,4 @@ This section will list all of the major changes that happened with the release o
 
 | Type | Ticket | Description |
 | --- | --- | --- |
-| Feature | I-1064 | Added support for [license](/momentum/4/before-you-begin#momentum-license) signatures using ECDSA P-256 with SHA-256 ([FIPS 186-4](https://csrc.nist.gov/pubs/fips/186-4/final)), required on deployments that enforce FIPS 140-3 (for example, SafeLogic CryptoComply, or OpenSSL 3.x configured with `default_properties = fips=yes`). Existing DSA-2048 / SHA-1 licenses continue to validate on all other deployments, including OpenSSL 3.x with the FIPS provider loaded but without strict enforcement. |
+| Feature | I-1064 | Added support for [license](/momentum/4/before-you-begin#momentum-license) signatures using ECDSA P-256 with SHA-256. |

--- a/content/momentum/changelog/5/5-3-0.md
+++ b/content/momentum/changelog/5/5-3-0.md
@@ -1,0 +1,13 @@
+---
+lastUpdated: "07/01/2026"
+title: "Momentum 5.3.0 Changelog"
+description: "Momentum 5.3.0 was released on 2026-07-01. This section will list all of the major changes that happened with the release of Momentum 5.3.0. Depending on installation type, all changes may not be applicable"
+---
+
+This section will list all of the major changes that happened with the release of **Momentum 5.3.0**. Depending on installation type, all changes may not be applicable
+
+<a name="changelog.5.3.0.table"></a>
+
+| Type | Ticket | Description |
+| --- | --- | --- |
+| Feature | I-1064 | Added support for [license](/momentum/4/before-you-begin#momentum-license) signatures using ECDSA P-256 with SHA-256 ([FIPS 186-4](https://csrc.nist.gov/pubs/fips/186-4/final)), required on deployments that enforce FIPS 140-3 (for example, SafeLogic CryptoComply, or OpenSSL 3.x configured with `default_properties = fips=yes`). Existing DSA-2048 / SHA-1 licenses continue to validate on all other deployments, including OpenSSL 3.x with the FIPS provider loaded but without strict enforcement. |

--- a/content/momentum/changelog/5/5-3-0.md
+++ b/content/momentum/changelog/5/5-3-0.md
@@ -11,3 +11,4 @@ This section will list all of the major changes that happened with the release o
 | Type | Ticket | Description |
 | --- | --- | --- |
 | Feature | I-1064 | Added support for [license](/momentum/4/before-you-begin#momentum-license) signatures using ECDSA P-256 with SHA-256. |
+| Feature | I-1214 | Removed `msys-nodejs` RPM from the Momentum bundle, to be replaced with the 3rd-party `nodejs` package. Node.js LTS 24+ must be installed separately from the system or a vendor repository. |

--- a/content/momentum/changelog/5/index.md
+++ b/content/momentum/changelog/5/index.md
@@ -6,6 +6,7 @@ name: "Momentum 5.x Changelogs"
 description: "Momentum 5.x Changelogs"
 ---
 
+* [Momentum 5.3.0 Changelogs](/momentum/changelog/5/5-3-0)
 * [Momentum 5.2.1 Changelogs](/momentum/changelog/5/5-2-1)
 * [Momentum 5.2.0 Changelogs](/momentum/changelog/5/5-2-0)
 * [Momentum 5.1.1 Changelogs](/momentum/changelog/5/5-1-1)

--- a/content/momentum/navigation.yml
+++ b/content/momentum/navigation.yml
@@ -1981,6 +1981,8 @@
     - link: /momentum/changelog/5
       title: Momentum 5.x Changelog
       items:
+        - link: /momentum/changelog/5/5-3-0
+          title: Momentum 5.3.0 Changelog
         - link: /momentum/changelog/5/5-2-1
           title: Momentum 5.2.1 Changelog
         - link: /momentum/changelog/5/5-2-0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is inaccurate guidance around FIPS/OpenSSL configurations and upgrade requirements.
> 
> **Overview**
> Updates the Momentum licensing docs to note that **Momentum 5.3.0** introduces ECDSA P-256/SHA-256 signed licenses for deployments that *enforce* FIPS 140-3 at the crypto-library level, while clarifying that existing DSA/SHA-1 licenses remain valid elsewhere.
> 
> Adds a new `Momentum 5.3.0` changelog page (including the ECDSA license signature feature and the removal of the bundled `msys-nodejs` RPM) and wires it into the 5.x changelog index and `content/momentum/navigation.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f00133b5dbd05677dc2b31b70973fb93d9f8b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->