### PR TITLE
Notice about Node.js 24 to be installed separately (Momentum#1214)

### DIFF
--- a/content/momentum/changelog/5/5-3-0.md
+++ b/content/momentum/changelog/5/5-3-0.md
@@ -11,3 +11,4 @@ This section will list all of the major changes that happened with the release o
 | Type | Ticket | Description |
 | --- | --- | --- |
 | Feature | I-1064 | Added support for [license](/momentum/4/before-you-begin#momentum-license) signatures using ECDSA P-256 with SHA-256. |
+| Feature | I-1214 | Removed `msys-nodejs` RPM from the Momentum bundle, to be replaced with the 3rd-party `nodejs` package. Node.js LTS 24+ must be installed separately from the system or a vendor repository. |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the 5.3.0 changelog to reflect a packaging/dependency shift for Node.js.
> 
> **Overview**
> Updates the **Momentum 5.3.0 changelog** to add a new entry (I-1214) noting that the bundled `msys-nodejs` RPM has been removed in favor of a third-party `nodejs` package, and that **Node.js LTS 24+ must now be installed separately** via the OS or a vendor repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c271eba3d5fb2e51344a31b568b9c328852aed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->