### PR TITLE
New arguments in `reroute queue` (SparkPost/Momentum#1226)

### DIFF
--- a/content/momentum/4/console-commands/reroute-queue.md
+++ b/content/momentum/4/console-commands/reroute-queue.md
@@ -1,7 +1,7 @@
 ---
-lastUpdated: "03/26/2020"
+lastUpdated: "05/20/2026"
 title: "reroute queue"
-description: "reroute queue move messages from queues of one domain to queues of the other reroute queue domain name 1 domain name 2 The reroute queue command requires two domain names as its arguments It will move messages from queues of the first domain to the queues of the second domain..."
+description: "reroute queue ec_console move messages between domain queues selectively by metadata or RFC822 header match optional --meta --header filter"
 ---
 
 <a name="console_commands.reroute_queue"></a> 
@@ -11,7 +11,7 @@ reroute queue — move messages from queues of one domain to queues of the other
 
 ## Synopsis
 
-`reroute queue` { *`domain_name1`* } { *`domain_name2`* }
+`reroute queue` [ `--meta` *`key`* *`value`* | `--header` *`header_name`* *`header_line`* ] { *`domain_name1`* | `all` } { *`domain_name2`* }
 
 <a name="idp12689408"></a> 
 ## Description
@@ -22,3 +22,26 @@ The **reroute queue**       command requires two domain names as its arguments. 
 10:47:35 /tmp/2025> reroute queue relay.com newrelay.com
 Moved 100 messages from 'relay.com' to 'newrelay.com'
 ```
+
+You may substitute `all` for *`domain_name1`* to move messages out of **every** source domain's queues into *`domain_name2`*.
+
+<a name="reroute_queue_selective"></a>
+### Selective reroute (optional filter)
+
+Optional **`--meta`** / **`--header`** filtering uses the same matching rules as [**fail domain quiet**](/momentum/4/console-commands/fail-domain-quiet#fail_domain_quiet_selective). **`--header`** compares **physical header lines** only — see [**folded headers**](/momentum/4/console-commands/fail-domain-quiet#header_filter_physical_lines). Place **at most one** clause immediately after `reroute queue` and **before** the source domain. With a filter, only matching messages are moved; non-matching messages stay in the source domain's queues. Without a filter, every queued message for the source domain is moved (original behavior).
+
+You cannot combine `--meta` and `--header` in the same command.
+
+```
+10:47:35 /tmp/2025> reroute queue --meta mo_campaign_id summer-sale relay.com newrelay.com
+Moved 12 messages from 'relay.com' to 'newrelay.com'
+```
+
+```
+10:47:35 /tmp/2025> reroute queue --header X-Reroute-Pick alpha all newrelay.com
+Moved 4 messages from 'all' to 'newrelay.com'
+```
+
+## See Also
+
+The same `--meta` / `--header` filtering clause is accepted by the fail-family commands: [fail domain](/momentum/4/console-commands/fail-domain) · [fail domain quiet](/momentum/4/console-commands/fail-domain-quiet) · [fail all](/momentum/4/console-commands/fail-all) · [fail all quiet](/momentum/4/console-commands/fail-all-quiet) · [binding fail domain](/momentum/4/console-commands/binding-fail-domain) · [binding fail domain quiet](/momentum/4/console-commands/binding-fail-domain-quiet)

--- a/content/momentum/4/console-commands/reroute-queue.md
+++ b/content/momentum/4/console-commands/reroute-queue.md
@@ -28,7 +28,7 @@ You may substitute `all` for *`domain_name1`* to move messages out of **every** 
 <a name="reroute_queue_selective"></a>
 ### Selective reroute (optional filter)
 
-Optional **`--meta`** / **`--header`** filtering uses the same matching rules as [**fail domain quiet**](/momentum/4/console-commands/fail-domain-quiet#fail_domain_quiet_selective). **`--header`** compares **physical header lines** only — see [**folded headers**](/momentum/4/console-commands/fail-domain-quiet#header_filter_physical_lines). Place **at most one** clause immediately after `reroute queue` and **before** the source domain. With a filter, only matching messages are moved; non-matching messages stay in the source domain's queues. Without a filter, every queued message for the source domain is moved (original behavior).
+Optional **`--meta`** / **`--header`** filtering uses the same matching rules as the `fail` family of commands. **`--header`** compares **physical header lines** only — see [**folded headers**](/momentum/4/console-commands/fail-domain-quiet#header_filter_physical_lines). Place **at most one** clause immediately after `reroute queue` and **before** the source domain. With a filter, only matching messages are moved; non-matching messages stay in the source domain's queues. Without a filter, every queued message for the source domain is moved (original behavior).
 
 You cannot combine `--meta` and `--header` in the same command.
 

--- a/content/momentum/changelog/5/5-3-0.md
+++ b/content/momentum/changelog/5/5-3-0.md
@@ -12,3 +12,4 @@ This section will list all of the major changes that happened with the release o
 | --- | --- | --- |
 | Feature | I-1064 | Added support for [license](/momentum/4/before-you-begin#momentum-license) signatures using ECDSA P-256 with SHA-256. |
 | Feature | I-1214 | Removed `msys-nodejs` RPM from the Momentum bundle, to be replaced with the 3rd-party `nodejs` package. Node.js LTS 24+ must be installed separately from the system or a vendor repository. |
+| Feature | I-1225 | Added optional `--meta` / `--header` filtering to the [`reroute queue`](/momentum/4/console-commands/reroute-queue#reroute_queue_selective) console command, to selectively move queued messages by metadata or RFC822 header match. |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes describing new `reroute queue` arguments; no runtime or configuration logic is modified.
> 
> **Overview**
> Updates the `reroute queue` console command docs to reflect new usage: optional `--meta`/`--header` filtering (mutually exclusive, same semantics as fail-family commands) and support for using `all` as the source domain.
> 
> Adds examples and cross-references for header matching behavior, and records the feature in the Momentum `5.3.0` changelog (I-1225).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7aef2f78391c436577ae6d8f8d992669811d1bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->