### PR TITLE
Renaming log_hires_timestamp configuration opt (SparkPost/Momentum#1216)

### DIFF
--- a/content/momentum/4/config-options-summary.md
+++ b/content/momentum/4/config-options-summary.md
@@ -213,10 +213,10 @@ The `Version` column indicated the version(s) of Momentum that support the optio
 | [local_changes_only](/momentum/4/config/ref-local-changes-only) – Whether there is a file for writing local configuration change | na | false | 4.0 and later | global |
 | [log_active_interval](/momentum/4/modules/4-modules-cluster#option.log_active_interval) – Used to tune centralized logging (cluster-specific) | na | 1 | 4.0 and later | cluster |
 | [log_group](/momentum/4/modules/4-modules-cluster#option.log_group) – Whether or not panic log messages are broadcast over spread (cluster-specific) | na |   | 4.0 and later | cluster |
+| [log_hires_timestamp](/momentum/4/config/ref-log-hires-timestamp) – Enable microsecond resolution for log timestamps | na | false | 5.3 and later | global |
 | [log_idle_interval](/momentum/4/modules/4-modules-cluster#option.log_idle_interval) – Amount of time to sleep before looking for another segment (cluster-specific) | na | 10 | 4.0 and later | cluster |
 | [log_requests_to_paniclog](/momentum/3/3-rest/rest-http-listener) – Whether to log REST injection requests | sending | false | 4.0 and later | http_listener, listen, pathway, pathway_group, peer |
 | [Logfile](/momentum/4/config/ref-eccluster-conf#eccluster.conf.logs.logfile) – Describe the full path to the log file | na |   | 4.0 and later | logs |
-| [LogHiresTimestamp](/momentum/4/config/ref-log-hires-timestamp) – Enable microsecond resolution for log timestamps | na | false | 5.3 and later | global |
 | [logs](/momentum/4/config/ref-ecelerity-cluster-conf) – Define the location of the cluster manager logs (cluster-specific) | na |   | 4.0 and later | cluster |
 | [logs](/momentum/4/config/ref-eccluster-conf) *(scope)* – Configure centralized log files on the cluster manager | na |   | 4.0 and later | global |
 | [low_action](/momentum/4/modules/4-adaptive#modules.adaptive.low_action) – Action when the high threshold is not met but the low threshold is met | sending | "throttle" "down" | 4.0 and later | adaptive_sweep_rule |

--- a/content/momentum/4/config/ref-log-hires-timestamp.md
+++ b/content/momentum/4/config/ref-log-hires-timestamp.md
@@ -1,22 +1,22 @@
 ---
 lastUpdated: "07/01/2026"
-title: "LogHiresTimestamp"
-description: "LogHiresTimestamp enables microsecond resolution for log timestamps written by Momentum across the mainlog, bouncelog, rejectlog, paniclog, custom logs, and other logging modules"
+title: "log_hires_timestamp"
+description: "log_hires_timestamp enables microsecond resolution for log timestamps written by Momentum across the mainlog, bouncelog, rejectlog, paniclog, custom logs, and other logging modules"
 ---
 
 <a name="conf.ref.log_hires_timestamp"></a>
 ## Name
 
-LogHiresTimestamp — enable microsecond resolution for log timestamps
+log_hires_timestamp — enable microsecond resolution for log timestamps
 
 ## Synopsis
 
-`LogHiresTimestamp = true`
+`log_hires_timestamp = true`
 
 <a name="idp.log_hires_timestamp"></a>
 ## Description
 
-When `LogHiresTimestamp` is set to `true`, Momentum writes log timestamps with microsecond (1 µs) resolution instead of the default 1-second resolution.
+When `log_hires_timestamp` is set to `true`, Momentum writes log timestamps with microsecond (1 µs) resolution instead of the default 1-second resolution.
 
 ### Rationale
 
@@ -48,7 +48,7 @@ The effect on each timestamp depends on how it is rendered:
 
 *   **Formatted (`strftime`) timestamps.** Timestamps rendered through a `strftime(3)` format string — such as the `timestamp_format` of [chunk_logger](/momentum/4/modules/chunk-logger), the `%t{...}` macro of [custom_logger](/momentum/4/modules/custom-logger), or [timestampformat](/momentum/4/config/ref-timestampformat) — keep the configured format, but every `%S` or `%T` conversion is followed by a `.NNNNNN` six-digit microsecond fraction. For example, the default `[%a %d %b %Y %H:%M:%S] ` becomes `[%a %d %b %Y %H:%M:%S.NNNNNN] ` and renders as `[Mon 20 May 2026 14:32:17.482915] `.
 
-When `LogHiresTimestamp` is `false` (the default), timestamps are emitted exactly as in previous releases of Momentum, with 1-second resolution and no `.NNNNNN` fraction.
+When `log_hires_timestamp` is `false` (the default), timestamps are emitted exactly as in previous releases of Momentum, with 1-second resolution and no `.NNNNNN` fraction.
 
 ## Compatibility
 
@@ -57,12 +57,12 @@ Tools that parse the numeric epoch field must accept either 10 or 16 decimal dig
 <a name="idp.log_hires_timestamp.online"></a>
 ## Online Modification
 
-`LogHiresTimestamp` is not online-tunable. Changing the option requires a Momentum restart.
+`log_hires_timestamp` is not online-tunable. Changing the option requires a Momentum restart.
 
 <a name="idp.log_hires_timestamp.scope"></a>
 ## Scope
 
-`LogHiresTimestamp` is valid in the global scope.
+`log_hires_timestamp` is valid in the global scope.
 
 ## See Also
 

--- a/content/momentum/4/config/ref-timestampformat.md
+++ b/content/momentum/4/config/ref-timestampformat.md
@@ -19,8 +19,7 @@ timestampformat — set the timestamp format used when logging to stderr
 Sets the timestamp format used by Momentum when logging to `stderr`. This output is usually not seen unless you invoke **ecelerity** using the `-d` option. The default value is shown above.
 
 > **Note**
->
-> When [LogHiresTimestamp](/momentum/4/config/ref-log-hires-timestamp) is enabled (Momentum 5.3 and later), every `%S` or `%T` conversion in the configured format is automatically followed by a `.NNNNNN` six-digit microsecond fraction, so the default value renders as `[Mon 20 May 2026 14:32:17.482915] `.
+> When [log_hires_timestamp](/momentum/4/config/ref-log-hires-timestamp) is enabled (Momentum 5.3 and later), every `%S` or `%T` conversion in the configured format is automatically followed by a `.NNNNNN` six-digit microsecond fraction, so the default value renders as `[Mon 20 May 2026 14:32:17.482915] `.
 
 <a name="idp26785984"></a> 
 ## Scope

--- a/content/momentum/4/log-formats-bouncelog.md
+++ b/content/momentum/4/log-formats-bouncelog.md
@@ -7,8 +7,7 @@ description: "The bouncelog records both in band and out of band bounces It is c
 The `bouncelog` records both in-band and out-of-band bounces. It is configured in the [bounce_logger](/momentum/4/modules/bounce-logger) module.
 
 > **Note**
->
-> When [LogHiresTimestamp](/momentum/4/config/ref-log-hires-timestamp) is enabled (Momentum 5.3 and later), the timestamp field at offset `0` of every record is emitted as a 16-digit microseconds-since-epoch value (for example `1064868656123456`) instead of a 10-digit seconds-since-epoch value. The field remains a single integer with no separator.
+> When [log_hires_timestamp](/momentum/4/config/ref-log-hires-timestamp) is enabled (Momentum 5.3 and later), the timestamp field at offset `0` of every record is emitted as a 16-digit microseconds-since-epoch value (for example `1064868656123456`) instead of a 10-digit seconds-since-epoch value. The field remains a single integer with no separator.
 
 ### <a name="idp4696736"></a> Bounce Records
 

--- a/content/momentum/4/log-formats-mainlog.md
+++ b/content/momentum/4/log-formats-mainlog.md
@@ -11,8 +11,7 @@ Every event is written to the `mainlog` file as a single line. Fixed position co
 The following sections define the format for each event type.
 
 > **Note**
->
-> When [LogHiresTimestamp](/momentum/4/config/ref-log-hires-timestamp) is enabled (Momentum 5.3 and later), the timestamp field at offset `0` of every record is emitted as a 16-digit microseconds-since-epoch value (for example `1064868656123456`) instead of a 10-digit seconds-since-epoch value. The field remains a single integer with no separator.
+> When [log_hires_timestamp](/momentum/4/config/ref-log-hires-timestamp) is enabled (Momentum 5.3 and later), the timestamp field at offset `0` of every record is emitted as a 16-digit microseconds-since-epoch value (for example `1064868656123456`) instead of a 10-digit seconds-since-epoch value. The field remains a single integer with no separator.
 
 ### <a name="idp4862592"></a> Reception Records
 

--- a/content/momentum/4/log-formats-paniclog.md
+++ b/content/momentum/4/log-formats-paniclog.md
@@ -11,8 +11,7 @@ Under normal circumstances, Debug_Flags should be empty or should be omitted fro
 In addition, Momentum logs entries to the `paniclog` when the `log_requests_to_paniclog` option is enabled in the HTTP_Listener and its nested scopes.
 
 > **Note**
->
-> When [LogHiresTimestamp](/momentum/4/config/ref-log-hires-timestamp) is enabled (Momentum 5.3 and later), the leading timestamp of every record (the value preceding the `:` separator) is emitted as a 16-digit microseconds-since-epoch value (for example `1307461172123456:`) instead of a 10-digit seconds-since-epoch value. The value remains a single integer with no internal separator.
+> When [log_hires_timestamp](/momentum/4/config/ref-log-hires-timestamp) is enabled (Momentum 5.3 and later), the leading timestamp of every record (the value preceding the `:` separator) is emitted as a 16-digit microseconds-since-epoch value (for example `1307461172123456:`) instead of a 10-digit seconds-since-epoch value. The value remains a single integer with no internal separator.
 
 ### <a name="idp5044896"></a> Panic Records
 

--- a/content/momentum/4/log-formats-rejectlog.md
+++ b/content/momentum/4/log-formats-rejectlog.md
@@ -7,8 +7,7 @@ description: "The rejectlog stores records of inbound messages that are rejected
 The `rejectlog` stores records of inbound messages that are rejected by Momentum, either due to policy or protocol deviations. It lists the full context for all rejected messages, as well as a summary of why the message was rejected, and it is configured in the [ec_logger](/momentum/4/modules/ec-logger).
 
 > **Note**
->
-> When [LogHiresTimestamp](/momentum/4/config/ref-log-hires-timestamp) is enabled (Momentum 5.3 and later), the leading timestamp of every record (the value preceding the `:` separator) is emitted as a 16-digit microseconds-since-epoch value (for example `1236672125123456:`) instead of a 10-digit seconds-since-epoch value. The value remains a single integer with no internal separator.
+> When [log_hires_timestamp](/momentum/4/config/ref-log-hires-timestamp) is enabled (Momentum 5.3 and later), the leading timestamp of every record (the value preceding the `:` separator) is emitted as a 16-digit microseconds-since-epoch value (for example `1236672125123456:`) instead of a 10-digit seconds-since-epoch value. The value remains a single integer with no internal separator.
 
 ### <a name="idp5073872"></a> Rejection Records
 

--- a/content/momentum/changelog/5/5-3-0.md
+++ b/content/momentum/changelog/5/5-3-0.md
@@ -12,5 +12,5 @@ This section will list all of the major changes that happened with the release o
 | --- | --- | --- |
 | Feature | I-1064 | Added support for [license](/momentum/4/before-you-begin#momentum-license) signatures using ECDSA P-256 with SHA-256. |
 | Feature | I-1214 | Removed `msys-nodejs` RPM from the Momentum bundle, to be replaced with the 3rd-party `nodejs` package. Node.js LTS 24+ must be installed separately from the system or a vendor repository. |
-| Feature | I-1216 | Added the [LogHiresTimestamp](/momentum/4/config/ref-log-hires-timestamp) option to emit microsecond-resolution timestamps in the `mainlog`, `bouncelog`, `rejectlog`, `paniclog`, custom logs, chunk logs, and message generation logs, preserving event ordering when reading multiple log files together. |
+| Feature | I-1216 | Added the [log_hires_timestamp](/momentum/4/config/ref-log-hires-timestamp) option to emit microsecond-resolution timestamps in the `mainlog`, `bouncelog`, `rejectlog`, `paniclog`, custom logs, chunk logs, and message generation logs, preserving event ordering when reading multiple log files together. |
 | Fix | TASK-227757 | [`ha_proxy_client`](/momentum/4/modules/ha-proxy-client) now re-resolves a hostname-based `ha_proxy_server` during each health check, so backend IP changes are picked up automatically without restart. |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only rename of a configuration option and related cross-references; no runtime code changes or behavioral impact.
> 
> **Overview**
> Renames the documented high-resolution logging option from `LogHiresTimestamp` to `log_hires_timestamp` across the reference page, config option summary table, log format docs, and the 5.3.0 changelog.
> 
> Also normalizes a few markdown files by adding missing trailing newlines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832a509579ed036ad125b9ce2fe7ba08721b4970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->