### PR TITLE
Migrate to archive.sparkpost.com with host-conditional noindex

### DIFF
--- a/components/site/seo.tsx
+++ b/components/site/seo.tsx
@@ -17,7 +17,7 @@ const SEO = (props: SeoProps): JSX.Element => {
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <link rel="canonical" href={router.asPath}></link>
       <link rel="shortcut icon" type="image/png" href="/favicon.png" />
-      <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+      <meta name="robots" content="noindex, nofollow" />
       {title && (
         <>
           <title>{title}</title>

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,8 @@ package = "@netlify/plugin-nextjs"
   for = "/*"
 
   [headers.values]
+    X-Robots-Tag = "noindex, nofollow"
+
     Strict-Transport-Security = '''
     max-age=31536000;
     includeSubDomains;'''
@@ -47,7 +49,7 @@ package = "@netlify/plugin-nextjs"
       'self'
       data:
       fonts.gstatic.com
-      support.sparkpost.com;
+      archive.sparkpost.com;
     connect-src
       *
       data:

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,11 @@ package = "@netlify/plugin-nextjs"
   for = "/*"
 
   [headers.values]
+    # Applies to every host this deploy serves. The host-conditional-noindex
+    # edge function strips this header (and the noindex <meta> tag) for
+    # support.sparkpost.com requests during the CloudFront migration gap, so
+    # only archive.sparkpost.com (and deploy previews) actually receive it.
+    # See netlify/edge-functions/host-conditional-noindex.ts.
     X-Robots-Tag = "noindex, nofollow"
 
     Strict-Transport-Security = '''

--- a/netlify/edge-functions/host-conditional-noindex.ts
+++ b/netlify/edge-functions/host-conditional-noindex.ts
@@ -81,9 +81,12 @@ export default async (request: Request, context: Context): Promise<Response | vo
   }
 
   // Rebuild the response with the mutated body. content-length is dropped so
-  // Netlify can recompute it for the modified body.
+  // Netlify recomputes it. content-encoding is dropped because response.text()
+  // already decoded any gzip/brotli the origin sent — leaving the header on
+  // would tell the client to decompress a now-plain-text body and fail.
   const headers = new Headers(response.headers);
   headers.delete('content-length');
+  headers.delete('content-encoding');
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,

--- a/netlify/edge-functions/host-conditional-noindex.ts
+++ b/netlify/edge-functions/host-conditional-noindex.ts
@@ -1,0 +1,91 @@
+// Temporary edge function for the support.sparkpost.com → archive.sparkpost.com
+// migration. Until the CloudFront redirect distribution is live (then DNS for
+// support.sparkpost.com flips off Netlify), this single Netlify deploy serves
+// both hostnames. The desired SEO behavior is asymmetric:
+//
+//   archive.sparkpost.com: served as built — noindex <meta>, X-Robots-Tag, and
+//     Disallow: / in robots.txt all intact, so search engines drop the archive.
+//   support.sparkpost.com: keep search engines indexing as before, so existing
+//     link equity is preserved until the CloudFront layer can 301 it to bird.com.
+//
+// Without this function, the noindex signals (set in seo.tsx, netlify.toml, and
+// next-sitemap.js) would apply to both hostnames equally — which would start
+// deindexing support.sparkpost.com before the 301s exist, losing link equity
+// that would otherwise transfer to bird.com via the CloudFront redirects.
+//
+// This function differentiates by Host header:
+//   - support.sparkpost.com: strip X-Robots-Tag, strip the noindex <meta> from
+//     HTML responses, and override /robots.txt with a permissive version.
+//   - archive.sparkpost.com or any other host (deploy previews, *.netlify.app):
+//     pass through unmodified.
+//
+// REMOVE THIS FUNCTION (and the netlify.toml registration) once the CloudFront
+// cutover is complete — support.sparkpost.com will no longer hit Netlify, so the
+// hostname-conditional logic becomes dead code.
+
+import type { Context } from '@netlify/edge-functions';
+
+const INDEX_HOST = 'support.sparkpost.com';
+
+// Match <meta name="robots" content="...noindex..."> in either attribute order
+// and with whitespace variations. Only the noindex/nofollow robots meta is
+// targeted — any other meta tags (description, og:*, viewport, etc.) are left
+// alone.
+const NOINDEX_META_PATTERNS: RegExp[] = [
+  /<meta\s[^>]*name=["']robots["'][^>]*content=["'][^"']*noindex[^"']*["'][^>]*\/?>/gi,
+  /<meta\s[^>]*content=["'][^"']*noindex[^"']*["'][^>]*name=["']robots["'][^>]*\/?>/gi,
+];
+
+export default async (request: Request, context: Context): Promise<Response | void> => {
+  const host = request.headers.get('host') ?? '';
+
+  // Only act on support.sparkpost.com. Every other host — including
+  // archive.sparkpost.com, *.netlify.app deploy URLs, and deploy previews —
+  // passes through with whatever the build emits (i.e. noindex stays on).
+  if (host !== INDEX_HOST) return;
+
+  const url = new URL(request.url);
+
+  // Override /robots.txt with a permissive version so Google can crawl
+  // support.sparkpost.com normally. Without this, the built robots.txt's
+  // `Disallow: /` would block Google from re-crawling, which would prevent it
+  // from seeing the 301s once CloudFront comes online.
+  if (url.pathname === '/robots.txt') {
+    return new Response('User-agent: *\n', {
+      status: 200,
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  // For everything else, fetch the response normally, then mutate it.
+  const response = await context.next();
+
+  // Strip the noindex HTTP header (set globally in netlify.toml).
+  response.headers.delete('X-Robots-Tag');
+
+  // Only HTML responses can carry the noindex <meta> tag. Skip non-HTML
+  // (images, JS, CSS, JSON) to avoid pointlessly buffering large bodies.
+  const contentType = response.headers.get('content-type') ?? '';
+  if (!contentType.includes('text/html')) {
+    return response;
+  }
+
+  let body = await response.text();
+  for (const pattern of NOINDEX_META_PATTERNS) {
+    body = body.replace(pattern, '');
+  }
+
+  // Rebuild the response with the mutated body. content-length is dropped so
+  // Netlify can recompute it for the modified body.
+  const headers = new Headers(response.headers);
+  headers.delete('content-length');
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
+export const config = {
+  path: '/*',
+};

--- a/netlify/edge-functions/host-conditional-noindex.ts
+++ b/netlify/edge-functions/host-conditional-noindex.ts
@@ -14,8 +14,9 @@
 // that would otherwise transfer to bird.com via the CloudFront redirects.
 //
 // This function differentiates by Host header:
-//   - support.sparkpost.com: strip X-Robots-Tag, strip the noindex <meta> from
-//     HTML responses, and override /robots.txt with a permissive version.
+//   - support.sparkpost.com: override X-Robots-Tag with "all", strip the noindex
+//     <meta> from HTML responses, and override /robots.txt with a permissive
+//     version.
 //   - archive.sparkpost.com or any other host (deploy previews, *.netlify.app):
 //     pass through unmodified.
 //
@@ -60,8 +61,12 @@ export default async (request: Request, context: Context): Promise<Response | vo
   // For everything else, fetch the response normally, then mutate it.
   const response = await context.next();
 
-  // Strip the noindex HTTP header (set globally in netlify.toml).
-  response.headers.delete('X-Robots-Tag');
+  // Override the X-Robots-Tag set in netlify.toml. `delete()` on this header is
+  // silently ignored — Netlify re-applies the netlify.toml [[headers]] block
+  // after the edge function returns, but it respects values WE set. So we
+  // overwrite with "all" (canonical "ignore any prior noindex; index normally"),
+  // which Google treats as equivalent to no header at all.
+  response.headers.set('X-Robots-Tag', 'all');
 
   // Only HTML responses can carry the noindex <meta> tag. Skip non-HTML
   // (images, JS, CSS, JSON) to avoid pointlessly buffering large bodies.

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,11 +1,12 @@
 module.exports = {
-  siteUrl: process.env.SITE_URL || 'https://support.sparkpost.com',
+  siteUrl: process.env.SITE_URL || 'https://archive.sparkpost.com',
   generateRobotsTxt: true,
   sitemapSize: 5000,
   robotsTxtOptions: {
     policies: [
       {
         userAgent: '*',
+        disallow: ['/'],
       },
     ],
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     "@context/*": ["context/*"]
   },
   "include": ["next-env.d.ts", "yaml.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "netlify"]
 }


### PR DESCRIPTION
## Summary

Migrate the docs site to `archive.sparkpost.com` so the existing `support.sparkpost.com` hostname is free to be repointed at the new CloudFront redirect distribution (messagebird-dev/bird#2382, merged) that 301s every legacy URL to its closest bird.com counterpart. End goal: consolidate SEO link equity onto bird.com instead of fragmenting between two sites.

**This PR is half of a two-part change.** The other half is the CloudFront distribution (`bird#2382`). They have to land together for SEO — landing this PR alone (or far ahead of CloudFront) would deindex `support.sparkpost.com` while it still has all its inbound Google traffic, losing link equity that would otherwise transfer to bird.com. The edge function added here exists specifically to bridge that gap so the two pieces don't have to land simultaneously.

## Changes

### 1. Base URL change + noindex (for `archive.sparkpost.com`)

The new archive hostname needs to be configured everywhere and emit clear noindex signals so search engines drop it (and stop competing with bird.com).

- **`next-sitemap.js`**: default `siteUrl` → `https://archive.sparkpost.com`; `robots.txt` generation adds `Disallow: /` to the `*` policy.
- **`components/site/seo.tsx`**: `<meta name="robots">` content → `noindex, nofollow` (was `index, follow, max-image-preview:large, ...`).
- **`netlify.toml`**: add `X-Robots-Tag: noindex, nofollow` to the global `[[headers]]` block; CSP `font-src` `support.sparkpost.com` → `archive.sparkpost.com` (the prior value was hardcoded but functionally unused).

### 2. Host-conditional noindex (preserves `support.sparkpost.com` indexability during the gap)

Without this, the changes above would apply equally to both hostnames the Netlify deploy serves — including the current production `support.sparkpost.com`. That's incorrect during the period between this PR landing and the CloudFront cutover: `support.sparkpost.com` still has all its Google traffic, and deindexing it before the 301s exist loses equity rather than transferring it.

- **`netlify/edge-functions/host-conditional-noindex.ts`** (new) — a Netlify Edge Function that runs on every request and, for `Host: support.sparkpost.com` only:
  - strips `X-Robots-Tag` from response headers
  - strips `<meta name="robots" content="noindex,...">` from HTML responses
  - overrides `/robots.txt` with a permissive version (`User-agent: *`, no `Disallow`)

`archive.sparkpost.com` and all other hosts (deploy previews, `*.netlify.app`, etc.) pass through unmodified — noindex stays in place.

## After CloudFront cutover (out of scope here)

Once `support.sparkpost.com` DNS flips to the CloudFront distribution, Netlify never sees those requests again — every viewer hits CloudFront and gets 301'd to bird.com. At that point the edge function is dead code on the Netlify side. Remove it (and the netlify.toml comment pointing at it) in a small follow-up PR.

## Test plan

After deploy preview is up:

- [ ] `curl -I https://archive.sparkpost.com/docs/` → response includes `X-Robots-Tag: noindex, nofollow`
- [ ] `curl -I https://support.sparkpost.com/docs/` → response does NOT include `X-Robots-Tag`
- [ ] `curl -s https://archive.sparkpost.com/robots.txt` → contains `Disallow: /`
- [ ] `curl -s https://support.sparkpost.com/robots.txt` → permissive (`User-agent: *`), no `Disallow`
- [ ] View source on `https://archive.sparkpost.com/docs/...` → contains `<meta name="robots" content="noindex, nofollow">`
- [ ] View source on `https://support.sparkpost.com/docs/...` → does NOT contain that meta tag
- [ ] Cypress suite passes in CI (no test asserts on the old robots meta string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SEO and crawl behavior depend on correct Host-header branching in the edge function; a bug could deindex support.sparkpost.com or leave the archive indexed.
> 
> **Overview**
> Repoints the docs site’s default canonical URL to **`archive.sparkpost.com`** and applies **noindex** everywhere the build emits SEO signals: robots meta in `seo.tsx`, global **`X-Robots-Tag`** in `netlify.toml`, **`Disallow: /`** in generated `robots.txt` via `next-sitemap.js`, plus CSP **`font-src`** updated from `support.sparkpost.com` to `archive.sparkpost.com`.
> 
> Because one Netlify deploy still serves **`support.sparkpost.com`** until CloudFront/DNS cutover, a new **Netlify edge function** (`host-conditional-noindex.ts`) runs only for that host: it serves a permissive `/robots.txt`, sets **`X-Robots-Tag: all`**, and strips the noindex robots **`<meta>`** from HTML so production support URLs stay crawlable and don’t lose equity before 301s to bird.com. **`archive.sparkpost.com`** and other hosts pass through with noindex unchanged.
> 
> **`tsconfig.json`** excludes the `netlify/` folder so edge TypeScript isn’t typechecked with the Next app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54d49ea22a091b857ad05e235577f74f351d8cd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->