### PR TITLE
docs: fix broken SparkPost Postman collection link

### DIFF
--- a/content/docs/getting-started/getting-started-sparkpost.md
+++ b/content/docs/getting-started/getting-started-sparkpost.md
@@ -115,7 +115,7 @@ Here are migration guides for other popular Email Services:
 
 ## Sending Email
 
-If you'd like to dive right in, you can read the [API reference documentation](https://developers.sparkpost.com/api/) and we have a [collection](https://god.postman.co/run-collection/ee44dcd644445e8bd864?action=collection%2Fimport) for [Postman](https://www.postman.com/) to help you experiment with manual API calls.
+If you'd like to dive right in, you can read the [API reference documentation](https://developers.sparkpost.com/api/) and we have a [collection](https://raw.githubusercontent.com/SparkPost/postman-collection/master/collection/sparkpost-api.json.postman_collection.json) for [Postman](https://www.postman.com/) to help you experiment with manual API calls.
 
 In case you need it, SparkPost also supports [SMTP-based email delivery](#header-SMTP) with a few modern twists.
 

--- a/content/docs/tech-resources/inbound-email-relay-webhook.md
+++ b/content/docs/tech-resources/inbound-email-relay-webhook.md
@@ -28,7 +28,7 @@ Best practice recommendations for use of a relay webhook are simple and short. 
 Before you start you will need the following:
 
 * A Relay Webhook consumer: This is code that you write and host. This is what will process inbound emails relayed through SparkPost. You will need to have this ready before you set up your Relay Webhook. For testing, you could use a service like requestbin.com (https://requestbin.com) to set up a temporary consumer.
-* An API key with "Inbound Domains: Read/Write" and "Relay Webhooks: Read/Write" permissions. You're going to make some API calls, so you might want to download [Postman](https://www.postman.com) and get the free [SparkPost Postman collection](https://god.postman.co/run-collection/ee44dcd644445e8bd864?action=collection%2Fimport) to make this easier.
+* An API key with "Inbound Domains: Read/Write" and "Relay Webhooks: Read/Write" permissions. You're going to make some API calls, so you might want to download [Postman](https://www.postman.com) and get the free [SparkPost Postman collection](https://raw.githubusercontent.com/SparkPost/postman-collection/master/collection/sparkpost-api.json.postman_collection.json) to make this easier.
 
 Once you have these, there are three steps to setting up your Relay Webhook:
 
@@ -79,7 +79,7 @@ You can check your MX record propagation [here](https://www.whatsmydns.net/#MX)
 
 ## Create an Inbound Domain
 
-This is the domain that users will send email to. You can send a POST request to https:<span></span>//api.sparkpost.com/api/v1/inbound-domains or use our [Postman collection](https://god.postman.co/run-collection/ee44dcd644445e8bd864?action=collection%2Fimport) to create your [Inbound Domain](https://developers.sparkpost.com/api/inbound-domains.html). Make sure to set your API key as the Authorization header under the "headers" tab and to set your domain under the "body" tab.
+This is the domain that users will send email to. You can send a POST request to https:<span></span>//api.sparkpost.com/api/v1/inbound-domains or use our [Postman collection](https://raw.githubusercontent.com/SparkPost/postman-collection/master/collection/sparkpost-api.json.postman_collection.json) to create your [Inbound Domain](https://developers.sparkpost.com/api/inbound-domains.html). Make sure to set your API key as the Authorization header under the "headers" tab and to set your domain under the "body" tab.
 
 ## Create a Relay Webhook
 


### PR DESCRIPTION
## Summary
- The `god.postman.co/run-collection/...` link for the SparkPost Postman collection is broken.
- Replaced it with the raw collection JSON on GitHub (`raw.githubusercontent.com/SparkPost/postman-collection/master/collection/sparkpost-api.json.postman_collection.json`), which works both when clicked directly and via Postman's import-by-URL flow.

## Test plan
- [ ] Confirm the new link resolves and downloads valid JSON
- [ ] Confirm the JSON imports cleanly into Postman

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link updates with no application, API, or security behavior changes.
> 
> **Overview**
> Replaces the broken `god.postman.co/run-collection/...` URLs with the **raw Postman collection JSON** on GitHub (`SparkPost/postman-collection`) in **getting-started-sparkpost** (Sending Email) and **inbound-email-relay-webhook** (Getting Started and Create an Inbound Domain).
> 
> Readers can import the collection via Postman’s import-by-URL flow or by downloading the JSON directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15bd56f066bfdbd743f0375261bf21f089259beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->