### PR TITLE
Momentum#1266 late changes: EOL and setup for manuals in next releases

### DIFF
--- a/content/momentum/4/eol-policy.md
+++ b/content/momentum/4/eol-policy.md
@@ -65,7 +65,8 @@ Momentum version 5 became GA on March 1, 2025. Therefore:
 | Momentum 4.8.x                  | 2024/10/17 | 2026/3/1           | 2027/3/1       |
 | Momentum 5.0.x                  | 2025/3/1   | 2026/7/1           | TBD            |
 | Momentum 5.1.x                  | 2025/7/1   | 2027/1/31          | TBD            |
-| **Momentum 5.2.x**              | 2026/1/31  | TBD                | TBD            |
+| Momentum 5.2.x.                 | 2026/1/31  | 2027/7/28          | TBD            |
+| **Momentum 5.3.x**              | 2026/7/28  | TBD                | TBD            |
 
 > ¹ Momentum 4.4.x was superseded by 4.6, which was the last version supporting CentOS 7.
 >

--- a/pdf-build/Makefile
+++ b/pdf-build/Makefile
@@ -11,11 +11,14 @@
 # Usage (run from this directory):
 #   make            # build a PDF for every manual
 #   make list       # show what would be built
-#   make build/installation-manual.pdf   # build one manual
+#   make build/Momentum_5.3_Installation.pdf   # build one manual
 #   make clean      # remove generated PDFs
 
 PANDOC      ?= pandoc
 SRC_DIR     := ../content/momentum/manuals
+# PDF-only manuals: Markdown sources here get a PDF like any other manual but
+# are NOT rendered online (the site only serves pages under content/).
+PRIV_DIR    := private
 TEMPLATE    := templates/bird-manual.typ
 SHARED_META := templates/metadata.yaml
 BUILD_DIR   := build
@@ -26,8 +29,39 @@ FONT_DIR    := assets/fonts
 export TYPST_FONT_PATHS := $(FONT_DIR)
 
 # Every top-level Markdown file is a manual, except the section landing page.
-SOURCES := $(filter-out $(SRC_DIR)/index.md,$(wildcard $(SRC_DIR)/*.md))
-PDFS    := $(patsubst $(SRC_DIR)/%.md,$(BUILD_DIR)/%.pdf,$(SOURCES))
+SOURCES      := $(filter-out $(SRC_DIR)/index.md,$(wildcard $(SRC_DIR)/*.md))
+PRIV_SOURCES := $(wildcard $(PRIV_DIR)/*.md)
+
+# ---------------------------------------------------------------------------
+# PDF naming: Momentum_<version>_<Suffix>.pdf
+#
+# The 5.3 manuals were originally produced from DOCX exports named
+# Momentum_5.3_<Suffix>.docx, and the customer-facing PDFs must keep following
+# that pattern. From 5.4 on there are no DOCX sources anymore — the PDFs are
+# generated straight from edits to the .md files — so this table is the
+# durable record of each manual's historical name suffix. The <version> part
+# is read from each manual's own `version:` frontmatter, so bumping the
+# version in the .md automatically renames the PDF for the next release.
+#
+# When adding a new manual, add its slug -> suffix entry here; a slug with no
+# entry (or no version) falls back to <slug>.pdf.
+PDF_SUFFIX_installation-manual              := Installation
+PDF_SUFFIX_upgrade-manual                   := Upgrade
+PDF_SUFFIX_enabling-apis-message-generation := Enabling_TransAPI-MsgGen
+PDF_SUFFIX_enabling-webhooks                := Enabling_Webhooks
+PDF_SUFFIX_upgrading-webhooks               := Upgrading_Webhooks
+PDF_SUFFIX_release-notes                    := Release_Notes
+PDF_SUFFIX_rocky9-installation-manual       := Rocky9_Installation
+
+# $(call md_version,<file>): the version: "X.Y" value from the frontmatter.
+md_version = $(shell sed -n 's/^version:[[:space:]]*"\([^"]*\)".*/\1/p' $(1) | head -1)
+# $(call pdf_name,<slug>,<version>): the PDF basename (no extension).
+pdf_name   = $(if $(and $(PDF_SUFFIX_$(1)),$(2)),Momentum_$(2)_$(PDF_SUFFIX_$(1)),$(1))
+# $(call pdf_for,<file>): full PDF path for a manual source file.
+pdf_for    = $(BUILD_DIR)/$(call pdf_name,$(basename $(notdir $(1))),$(call md_version,$(1))).pdf
+# ---------------------------------------------------------------------------
+
+PDFS := $(foreach src,$(SOURCES) $(PRIV_SOURCES),$(call pdf_for,$(src)))
 
 # Shared inputs every PDF depends on. Listing the logos, fonts, and the Makefile
 # itself means `make` rebuilds when any of them change -- no manual `clean`.
@@ -37,35 +71,49 @@ DEPS    := $(TEMPLATE) $(SHARED_META) $(ASSETS) $(MAKEFILE_LIST)
 .PHONY: all list clean
 all: $(PDFS)
 
+# Intermediate Typst file for the manual being built (named after the .md
+# slug, not the PDF, so it stays predictable). Expanded per-recipe via $<.
+TYP = $(basename $(notdir $<)).typ
+
 # Two-step build: Pandoc -> Typst source, then compile with the typst CLI.
 # The intermediate .typ is emitted here in pdf-build/ (not build/) so the
 # template's relative `assets/...` logo paths resolve. It is removed after.
 #
 # `-tex_math_dollars`: disable $...$ math parsing so literal shell/config vars
 # like $NGINX_ROOT or $PATH in prose and tables are never treated as math.
-$(BUILD_DIR)/%.pdf: $(SRC_DIR)/%.md $(DEPS) | $(BUILD_DIR)
-	$(PANDOC) "$<" \
-	  --from=markdown-tex_math_dollars \
-	  --to=typst \
-	  --template=$(TEMPLATE) \
-	  --metadata-file=$(SHARED_META) \
-	  --toc --toc-depth=3 \
-	  --resource-path=".:$(SRC_DIR)" \
-	  --output="$*.typ"
-	@# Pandoc gives tables fixed percentage column widths (always full-width);
-	@# rewrite them to auto so the template can detect a table's natural width
-	@# and rotate genuinely wide ones onto their own landscape page.
-	@# Use a temp file + mv (not `sed -i`, whose syntax differs on BSD vs GNU).
-	sed -E '/^[[:space:]]*columns: \(/ s/[0-9.]+%/auto/g' "$*.typ" > "$*.typ.cols" && mv "$*.typ.cols" "$*.typ"
-	typst compile --font-path "$(FONT_DIR)" "$*.typ" "$@"
-	@rm -f "$*.typ"
-	@echo "Built $@"
+# Canned recipe shared by every manual rule generated below.
+define BUILD_PDF
+$(PANDOC) "$<" \
+  --from=markdown-tex_math_dollars \
+  --to=typst \
+  --template=$(TEMPLATE) \
+  --metadata-file=$(SHARED_META) \
+  --toc --toc-depth=3 \
+  --resource-path=".:$(dir $<)" \
+  --output="$(TYP)"
+@# Pandoc gives tables fixed percentage column widths (always full-width);
+@# rewrite them to auto so the template can detect a table's natural width
+@# and rotate genuinely wide ones onto their own landscape page.
+@# Use a temp file + mv (not `sed -i`, whose syntax differs on BSD vs GNU).
+sed -E '/^[[:space:]]*columns: \(/ s/[0-9.]+%/auto/g' "$(TYP)" > "$(TYP).cols" && mv "$(TYP).cols" "$(TYP)"
+typst compile --font-path "$(FONT_DIR)" "$(TYP)" "$@"
+@rm -f "$(TYP)"
+@echo "Built $@"
+endef
+
+# The PDF basename is unrelated to the .md basename, so a pattern rule cannot
+# express the mapping — generate one explicit rule per manual instead.
+define MANUAL_RULE
+$(call pdf_for,$(1)): $(1) $(DEPS) | $(BUILD_DIR)
+	$$(BUILD_PDF)
+endef
+$(foreach src,$(SOURCES) $(PRIV_SOURCES),$(eval $(call MANUAL_RULE,$(src))))
 
 $(BUILD_DIR):
 	@mkdir -p $(BUILD_DIR)
 
 list:
-	@echo "Sources:"; for s in $(SOURCES); do echo "  $$s"; done
+	@echo "Sources:"; for s in $(SOURCES) $(PRIV_SOURCES); do echo "  $$s"; done
 	@echo "PDFs:";    for p in $(PDFS);    do echo "  $$p"; done
 
 clean:

--- a/pdf-build/README.md
+++ b/pdf-build/README.md
@@ -13,6 +13,10 @@ content/momentum/manuals/*.md   ──► online pages (Next.js site)
 One manual = one Markdown file = one online page = one PDF. There is a single
 source of truth; the PDF is a build artifact.
 
+Exception: manuals under `private/` in this directory are **PDF-only** — they
+get a branded PDF like any other manual but are never rendered online (the
+site only serves pages under `content/`).
+
 ## Toolchain
 
 Pandoc (≥ 3.x) and the Typst CLI. These are not npm packages — install once per
@@ -29,11 +33,33 @@ brew install pandoc typst        # macOS
 cd pdf-build
 make            # build every manual into build/
 make list       # show what would be built
-make build/installation-manual.pdf   # build a single manual
+make build/Momentum_5.3_Installation.pdf   # build a single manual
 make clean      # remove generated PDFs
 ```
 
 Generated PDFs land in `build/` (git-ignored).
+
+### PDF naming
+
+PDFs are named `Momentum_<version>_<Suffix>.pdf` — the pattern of the original
+5.3 DOCX exports the manuals were converted from. The DOCX files are no longer
+part of the flow (from 5.4 on, changes are made directly in the `.md` sources),
+so the `PDF_SUFFIX_*` table in the `Makefile` is the durable record of each
+manual's historical suffix:
+
+| `.md` slug | PDF suffix |
+| --- | --- |
+| `installation-manual` | `Installation` |
+| `upgrade-manual` | `Upgrade` |
+| `enabling-apis-message-generation` | `Enabling_TransAPI-MsgGen` |
+| `enabling-webhooks` | `Enabling_Webhooks` |
+| `upgrading-webhooks` | `Upgrading_Webhooks` |
+| `release-notes` | `Release_Notes` |
+| `rocky9-installation-manual` | `Rocky9_Installation` |
+
+The `<version>` part is read from each manual's `version:` frontmatter, so
+bumping the version in the `.md` automatically renames the PDF for the next
+release. A slug with no table entry falls back to `<slug>.pdf`.
 
 The build is incremental: `make` rebuilds a manual when its `.md` changes, and
 rebuilds **all** manuals when a shared input changes (the template,
@@ -46,6 +72,7 @@ rebuilds **all** manuals when a shared input changes (the template,
 | Path | Purpose |
 | --- | --- |
 | `../content/momentum/manuals/*.md` | Manual sources (also served online) |
+| `private/*.md` | PDF-only manual sources (never served online) |
 | `templates/bird-manual.typ` | Pandoc→Typst template with the Bird-branded cover, header/footer, and styling |
 | `templates/metadata.yaml` | Brand/layout defaults shared by every manual |
 | `assets/` | Logo and (optional) brand fonts |
@@ -92,10 +119,14 @@ date: "June 2026"
      not nested inside a list item or blockquote (Typst cannot start a new page
      inside a container, and the build will error). If a wide table belongs
      under a step, lift it out to its own paragraph.
+   - **PDF-only manuals**: save the `.md` under `pdf-build/private/` instead
+     of `content/momentum/manuals/`, and skip step 2.
 2. Add the page to the menu: a sub-item under the **Online manuals** node in
    `content/momentum/navigation.yml`, and a link in
    `content/momentum/manuals/index.md`.
-3. `make build/<name>.pdf` and review the output.
+3. Add the manual's slug → suffix entry to the `PDF_SUFFIX_*` table in the
+   `Makefile` (see [PDF naming](#pdf-naming)), then `make` and review the
+   output.
 
 ## Branding
 

--- a/pdf-build/private/rocky9-installation-manual.md
+++ b/pdf-build/private/rocky9-installation-manual.md
@@ -1,0 +1,348 @@
+---
+title: "Installation Manual (Rocky Linux 9)"
+subtitle: "Momentum"
+version: "5.3"
+date: "July 2026"
+description: "How to install Momentum 5.3 on Rocky Linux 9 — as a single standalone MTA or in a cluster with a Cluster Manager node — including pre-requisites, node configuration, optional PostgreSQL setup, and starting services."
+lastUpdated: "07/24/2026"
+---
+
+# 1. Introduction
+
+- The Momentum 5.3 configuration is primarily intended for new Momentum on-premise installations in a Rocky Linux 9 operating environment.
+
+- Following the initial installation of the Momentum 5.3 release configuration, the 5.3 Webhooks functions and/or the REST Transmissions API and Inline Message Generation functions can be added in separate procedures if desired.
+
+  - In 5.3 (as introduced in 4.2.31), these features no longer require the installation of the Cassandra database. Instructions for adding these capabilities are available from Momentum Customer Support. Please contact them before doing the upgrade if the additional functionality is desired.
+
+- Installation can be done as a single standalone MTA or in a cluster configuration. In a standalone MTA configuration, there is no log aggregation. In a cluster configuration, a cluster manager is used for cluster-wide log aggregation of files from the MTA nodes. The instructions in this manual will note where they apply to only one of these configurations.
+
+# 2. Download the Software Bundle
+
+1.  Download the Momentum software bundle from the [Message Systems Support](https://support.messagesystems.com/start.php) website for every node that you will install or upgrade. For Rocky Linux 9, the same bundle of Red Hat Enterprise Linux (RHEL) version 9 is used.
+
+2.  Copy the bundle to the **/var/tmp/** directory on each node. Note that throughout this document, specific bundle filenames are shown, and their resulting install directory names are only examples.
+
+    ```bash
+    cp momentum-mta-bundle-5.3.x.yyyyy.rhel9.<arch>.tar.gz /var/tmp/
+    ```
+
+    where **\<arch\>** is **x86_64** or **aarch64**.
+
+    > **Note:** As introduced in 4.4.0, the MTA-only bundles contain all the necessary components for a subsequent enabling of the 5.3 Webhooks and/or the REST APIs and Message Generation after the initial installation.
+
+3.  Unpack the tarball on each node and set the repository directory.
+
+    ```bash
+    cd /var/tmp
+    tar -zxf momentum-mta-bundle-5.3.x.yyyyy.rhel9.<arch>.tar.gz
+    cd momentum-mta-5.3.x.yyyyy/
+    ./setrepodir
+    ```
+
+    > **Note:** The **./setrepodir** script establishes some environmental parameters for the installation. If the installation is not completed within the same terminal session in which it was started, the **./setrepodir** command _must_ be re-executed in any new session(s) before executing any of the **dnf** commands for the installation.
+
+4.  Your valid Momentum license file will be in each MTA node's **/opt/msys/ecelerity/etc** folder. Your licenses should be pulled automatically once they have been issued.
+
+5.  If your node does not have public internet access during installation, you will need to manually add your valid Momentum license files.
+
+# 3. Installing Momentum
+
+## 3.1. Install EPEL
+
+Momentum has some dependencies on packages provided by the _Extra Packages for Enterprise Linux_ (EPEL). Make sure it is installed before installing Momentum.
+
+```bash
+sudo dnf install -y epel-release
+```
+
+## 3.2. Installing the MTA Node(s)
+
+For every node you designate as an MTA, perform the following:
+
+```bash
+cd /var/tmp/momentum-mta-5.3.x.yyyyy
+sudo dnf install -y --config momentum.repo --enablerepo momentum msys-role-mta
+```
+
+> **Note:** If you receive an error saying **libssh2** is needed, proceed with a manual installation of **libssh2**.
+
+> **Note:** A few utilities under **/opt/msys/ecelerity/bin** may need additional Perl modules, which can be retrieved from CPAN using the command: **sudo cpan install \<module\>**. Alternatively, you may be able to find the corresponding RPM package for installation on your platform.
+
+## 3.3. [OPTIONAL] Installing Cluster Manager Node
+
+> **Note:** Skip this whole section for single-node installation.
+
+In a fully clustered environment, you can designate a dedicated host as the Cluster Manager. This node can then:
+
+- Consolidate all of the MTA logs (acting as a "Log Aggregator")
+
+- Act as one of the MSGC server members to ensure that clustered metrics are maintained
+
+- (If some of these Momentum features - mostly legacy - are intended to be used: web console/UI; stats producer; mobility; seedlist/ReturnPath integration, then the Cluster Manager is the node where you run the shared PostgreSQL database)
+
+### 3.3.1. Install PostgreSQL
+
+The PostgreSQL packages supplied by the standard repositories of Rocky 9 are no longer supported. Therefore, it is recommended to install a valid package from the official PostgreSQL repository:
+
+```bash
+sudo dnf install -y \
+  https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-<arch>/pgdg-redhat-repo-latest.noarch.rpm
+sudo dnf -qy module disable postgresql
+sudo dnf install -y postgresql16-server
+sudo /usr/pgsql-16/bin/postgresql-16-setup initdb
+sudo systemctl enable --now postgresql-16
+export PATH=/usr/pgsql-16/bin:$PATH  # e.g. for psql
+```
+
+where **\<arch\>** is **x86_64** or **aarch64**.
+
+### 3.3.2. Set Up the Cluster Manager
+
+Install these packages on the Cluster Manager node:
+
+```bash
+cd /var/tmp/momentum-mta-5.3.x.yyyyy
+sudo dnf install -y --config momentum.repo --enablerepo momentum \
+  msys-role-manager msys-role-db msys-ecelerity-mobility-db
+```
+
+# 4. Configuring the Nodes
+
+## 4.1. Common Configuration
+
+Momentum offers numerous configuration options, allowing for the customization of behavior to suit a wide range of needs. The **sample-configs/default** directory contains a basic set of options that will allow the basic services to start. For every node, regardless of whether it is the Cluster Manager or an MTA, copy the required files from the **sample-configs/default** directory to the active configuration directory. These can be adjusted as required once the initial installation is completed.
+
+```bash
+sudo -u ecuser mkdir -p /opt/msys/ecelerity/etc/conf/default
+cd /opt/msys/ecelerity/etc/sample-configs/default
+sudo -u ecuser cp {ecelerity.conf,ecelerity-cluster.conf,common.conf} \
+  /opt/msys/ecelerity/etc/conf/default/
+```
+
+## 4.2. License
+
+Your valid Momentum license file will be in each node's **/opt/msys/ecelerity/etc** folder. Your licenses should be pulled automatically once they have been issued. You can also run the following command to pull your license:
+
+```bash
+/opt/msys/ecelerity/bin/ec_lic -f
+```
+
+If your node does not have public internet access during installation, you will need to manually add your valid Momentum license files.
+
+> **Note:** Depending on whether FIPS mode is enabled and which versions of the FIPS modules are running in your environment, the Momentum 5.3 license may be constrained to be signed by specific methods. If the regular license file is not validated under such restrictions, please contact the Momentum Customer Support to obtain a proper license file for your case.
+
+## 4.3. MTA Configuration
+
+### 4.3.1. [OPTIONAL] Set Up the Adaptive Live Update
+
+Adaptive's **lu_pull** utility has a configuration file that controls automatic updates to **adaptive_rules.lua** and bounces classification files. If Momentum is configured to use adaptive, and there's no **liveupdate.conf** file in **/opt/msys/ecelerity/etc**, create one from the **sample-config**:
+
+```bash
+cd /opt/msys/ecelerity/etc/sample-configs
+sudo -u ecuser cp liveupdate.conf /opt/msys/ecelerity/etc/
+```
+
+## 4.4. [OPTIONAL] Cluster Configuration
+
+> **Note:** Skip this whole section for single-node installation.
+
+### 4.4.1. Basic Configuration
+
+1.  Copy the **eccluster.conf** file from the **sample-configs/default** directory:
+
+    ```bash
+    cd /opt/msys/ecelerity/etc/sample-configs/default
+    sudo -u ecuser cp eccluster.conf /opt/msys/ecelerity/etc/conf/default/
+    ```
+
+2.  Copy the **msgc_server.conf** file to the appropriate location on the Cluster Manager node:
+
+    ```bash
+    sudo -u ecuser mkdir -p /opt/msys/ecelerity/etc/conf/global
+    sudo -u ecuser cp \
+      /opt/msys/ecelerity/etc/sample-configs/default/msgc_server.conf \
+      /opt/msys/ecelerity/etc/conf/global/
+    ```
+
+### 4.4.2. [OPTIONAL] Configure the Log Aggregation
+
+1.  Edit **/opt/msys/ecelerity/etc/conf/global/msgc_server.conf.** For EVERY node in the cluster (i.e., the Cluster Manager and all MTAs) you are installing, substitute the hostnames and IP addresses as appropriate.
+
+    ```
+    msgc_server {
+      peers = [
+        mgr.yourdomain.com = "10.77.0.219"
+        mta1.yourdomain.com = "10.77.1.6"
+        mta2.yourdomain.com = "10.77.1.8"
+        ...
+        mtaN.yourdomain.com = "10.77.1.10"
+      ]
+    }
+    ```
+
+2.  Remove the aggregator comment prefix (**#aggr#**) wherever it occurs in the **/opt/msys/ecelerity/etc/conf/default/ecelerity-cluster.conf** configuration file.
+
+    ```
+    #aggr# ec_logger "ec_logger_cluster" {
+    #aggr#   mainlog = "cluster:///var/log/ecelerity/mainlog.cluster=>master"
+    #aggr#   paniclog = "cluster:///var/log/ecelerity/paniclog.cluster=>master"
+    #aggr#   rejectlog = "cluster:///var/log/ecelerity/rejectlog.cluster=>master"
+    #aggr#   acctlog = "cluster:///var/log/ecelerity/acctlog.cluster=>master"
+    #aggr# }
+    #aggr# bounce_logger "bounce_logger_cluster" {
+    #aggr#   bouncelog = "cluster:///var/log/ecelerity/bouncelog.cluster=>master"
+    #aggr# }
+    (...)
+    cluster {
+      logs = [
+    #aggr#   rejectlog = "/var/log/ecelerity/rejectlog.cluster"
+    #aggr#   paniclog = "/var/log/ecelerity/paniclog.cluster"
+    #aggr#   mainlog = "/var/log/ecelerity/mainlog.cluster"
+    #aggr#   acctlog = "/var/log/ecelerity/acctlog.cluster"
+    #aggr#   bouncelog = "/var/log/ecelerity/bouncelog.cluster"
+      ]
+    }
+    ```
+
+3.  For EACH MTA node in the cluster, copy both **msgc_server.conf** and **ecelerity-cluster.conf** files from the Cluster Manager node.
+
+    ```bash
+    sudo -u ecuser mkdir -p /opt/msys/ecelerity/etc/conf/global
+    cd /opt/msys/ecelerity/etc/conf/
+    scp mgr.yourdomain.com:/opt/msys/ecelerity/etc/conf/global/msgc_server.conf \
+      global/
+    scp \
+      mgr.yourdomain.com:/opt/msys/ecelerity/etc/conf/default/ecelerity-cluster.conf \
+      default/
+    ```
+
+4.  For EVERY node in the cluster (the Cluster Manager and all MTAs), include the cluster configuration file by removing the comment character (#) from this line in **ecelerity.conf**:
+
+    ```
+    # include "ecelerity-cluster.conf"
+    ```
+
+### 4.4.3. [OPTIONAL] Configure the PostgreSQL Database Server
+
+1.  **(IMPORTANT!)** For this particular setup, change to the **root** user in the Cluster Manager node.
+
+    ```bash
+    sudo su
+    ```
+
+2.  Install PostgreSQL in the Cluster Manager node following the instructions of section 3.3.1 (may have already been installed due to former dependencies).
+
+3.  Install the database schema provided by Momentum:
+
+    ```bash
+    cd /var/tmp/momentum-mta-5.3.x.yyyyy
+    dnf install -y --config momentum.repo --enablerepo momentum \
+      msys-ecelerity-schema
+    ```
+
+4.  Create a random service password file named **.svcpasswd** that can be used by the various services to access the database. Additionally, logging into the console remotely requires an additional username/password combination. By convention, this user is **admin**, but you can use any username you want.
+
+    ```bash
+    mkdir -p /opt/msys/etc
+    < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c8 >/opt/msys/etc/.svcpasswd
+    export SVCPASSWD=`cat /opt/msys/etc/.svcpasswd`
+    export ADMINPASS=admin
+    ```
+
+5.  Create the PostgreSQL database host file. Momentum requires a PostgreSQL database for console authentication and other minor modules. This is a very low-usage database that is installed on the Cluster Manager for simplicity in cluster installations.
+
+    ```bash
+    MyHostName=`hostname -f`
+    echo $MyHostName > /opt/msys/etc/.dbhost
+    ```
+
+6.  Configure PostgreSQL with the "ecelerity" schema.
+
+    ```bash
+    systemctl restart postgresql-16
+    sleep 40
+    cd /opt/msys/ecelerity/etc
+    ../bin/init_schema --password $SVCPASSWD --admin-password $ADMINPASS
+    ```
+
+    You should see something like this:
+
+    ```
+    Loading sql/common.sql into common...done!
+    Loading sql/console.sql into console...done!
+    Loading sql/returnpath.sql into returnpath...done!
+    Loading sql/seedlist.sql into seedlist...done!
+    Loading sql/adaptive.sql into adaptive...done!
+    ```
+
+7.  **Only if** there were any problems creating the "ecelerity" database in PostgreSQL, invoke the following command:
+
+    > **Note:** DO NOT run this command if there were no errors when executing **init_schema** in the previous step.
+
+    ```bash
+    /opt/msys/3rdParty/bin/dropdb -U ecuser ecelerity
+    ```
+
+    Then try to rerun **init_schema**.
+
+8.  Create a **/opt/msys/ecelerity/etc/conf/default/ecdb.conf** file with the database source information.
+
+    ```bash
+    export MyHostName=`cat /opt/msys/etc/.dbhost`
+    export SVCPASSWD=`cat /opt/msys/etc/.svcpasswd`
+    cat << EOT > /opt/msys/ecelerity/etc/conf/default/ecdb.conf
+    Datasource "ecdb" { uri = ( "pgsql:host=$MyHostName;dbname=ecelerity;user=ecuser;password=$SVCPASSWD" )}
+    EOT
+    ```
+
+9.  Add the following line to the **/opt/msys/ecelerity/etc/conf/default/eccluster.conf** file:
+
+    ```
+    readonly_include "ecdb.conf"
+    ```
+
+    > **Note:** Make sure to add the line AFTER the inclusion of **common.conf** file, otherwise the database configuration in **ecdb.conf** may be overloaded by **common.conf**.
+
+10. Copy the **ecdb.conf** file to all MTA nodes in the cluster.
+
+11. Add this line to the **/opt/msys/ecelerity/etc/conf/default/ecelerity.conf** configuration file on EACH MTA node.
+
+    ```
+    readonly_include "ecdb.conf"
+    ```
+
+12. Remove (or comment out) these lines from the **common.conf** file in EVERY node:
+
+    ```
+    # Datasource "ecdb" {
+    #   uri = ( "pgsql:dbname=ecelerity;user=ecuser" )
+    # }
+    ```
+
+    Otherwise, they can inadvertently overload the settings from **ecdb.conf**.
+
+13. Test the Momentum configuration in EVERY node (the Cluster Manager and all MTAs). Enter the username admin and your $ADMINPASS password when prompted. After logging in, you will get a ">" prompt and will be able to type various commands, such as "version" and "summary".
+
+    ```bash
+    /opt/msys/ecelerity/bin/ec_console shim://
+    # Login with admin/$ADMINPASS.
+    # (...)
+    quit
+    ```
+
+# 5. Start Momentum Services
+
+Depending on the node's role, start the relevant service.
+
+- If the node is the Cluster Manager:
+
+  ```bash
+  sudo systemctl start eccmgr
+  ```
+
+- If the node is an MTA:
+
+  ```bash
+  sudo systemctl start ecelerity
+  ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and build-tooling changes only; no runtime application or security-sensitive code paths.
> 
> **Overview**
> Updates the **Momentum 4 EOL policy** so **5.2.x** has an end-of-maintenance date (**2027/7/28**) and **5.3.x** is listed as the current GA line (**2026/7/28**), replacing 5.2.x as the highlighted release.
> 
> The **pdf-build** pipeline now emits customer-facing names like `Momentum_<version>_<Suffix>.pdf` (suffixes from a `PDF_SUFFIX_*` table; version from each manual’s frontmatter), supports **PDF-only** sources under `pdf-build/private/` (not published on the site), and refactors the Makefile into a shared `BUILD_PDF` recipe with per-manual rules.
> 
> Adds a new **PDF-only** Rocky Linux 9 **Momentum 5.3 installation** manual (`Momentum_5.3_Rocky9_Installation.pdf`) and documents the workflow in `pdf-build/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31b4ea6b188698162c3591aa4c828898339380b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->