### PR TITLE
Momentum#1472 document the %OC custom_logger macro

### DIFF
--- a/content/momentum/4/log-formats-mainlog.md
+++ b/content/momentum/4/log-formats-mainlog.md
@@ -32,7 +32,7 @@ The following is a description of the fields:
 | 0 | 1064868656 | Date of reception in Unix timestamp format (seconds since 00:00:00 Jan 1, 1970) |
 | 1 | 00/00-25004-31B987F3 | Message's unique message-id |
 | 2 | 00/00-03736-F4101B54 | Batch ID |
-| 3 | 00/00-04532-A3456B54 | Connection ID |
+| 3 | 00/00-04532-A3456B54 | Connection ID: the inbound connection the message was received over |
 | 4 | R | `R` indicating a reception |
 | 5 | bob | Localpart of the recipient |
 | 6 | example.fict | Domain of the recipient |
@@ -63,7 +63,7 @@ The following is a description of the fields:
 | 0 | 1064871280 | Date of delivery in Unix timestamp format (seconds since 00:00:00 Jan 1, 1970) |
 | 1 | 20/00-25593-945A87F3 | Message's unique message-id |
 | 2 | 00/00-03736-F4101B54 | Batch ID |
-| 3 | 00/00-04532-A3456B54 | Connection ID |
+| 3 | 00/00-04532-A3456B54 | Connection ID: the outbound connection delivery was attempted over. Each attempt uses a new connection, so retries log different values. |
 | 4 | D | `D` indicating a successful delivery or `X` indicating a transfer between nodes, in a cluster configuration.<br> `X` entries appear in the delivery log on the transferring node indicating that the message left for another cluster node, while `R` entries appear in the reception log on the node receiving the message with `xfer` in its protocol field. |
 | 5 | postalengine.com | Destination domain |
 | 6 | 266 | Size in bytes of the delivered message |
@@ -92,7 +92,7 @@ The following is a description of the fields:
 | 0 | 1064869327 | Date of transient failure in Unix timestamp format (seconds since 00:00:00 Jan 1, 1970) |
 | 1 | 00/00-25004-31B987F3 | Message's unique message-id |
 | 2 | 00/00-03736-F4101B54 | Batch ID |
-| 3 | 00/00-04532-A3456B54 | Connection ID |
+| 3 | 00/00-04532-A3456B54 | Connection ID: the outbound connection delivery was attempted over. Each attempt uses a new connection, so retries log different values. |
 | 4 | T | `T` indicating a transient failure |
 | 5 | example.fict | Destination domain |
 | 6 | 0 | Number of bytes of data transferred before the failure occurred. A value of 0 indicates no connection could be made. |
@@ -123,7 +123,7 @@ The following is a description of the fields:
 | 0 | 1064870847 | Date of permanent failure in Unix timestamp format (seconds since 00:00:00 Jan 1, 1970) |
 | 1 | 10/00-25593-393A87F3 | Message's unique message-id |
 | 2 | 00/00-03736-F4101B54 | Batch ID |
-| 3 | 00/00-04532-A3456B54 | Connection ID |
+| 3 | 00/00-04532-A3456B54 | Connection ID: the outbound connection delivery was attempted over. Each attempt uses a new connection, so retries log different values. |
 | 4 | P | `P` indicating a permanent failure, such as an in-band bounce |
 | 5 | postalengine.com | Destination domain |
 | 6 | 31 | Number of bytes of data transferred before the failure occurred. In this example, 31 bytes were transferred before the remote server returned its error. |

--- a/content/momentum/4/modules/custom-logger.md
+++ b/content/momentum/4/modules/custom-logger.md
@@ -572,7 +572,7 @@ Number of the heuristic classification of the message from the DSN received from
 
 <dd>
 
-Connection ID
+Inbound connection ID: the connection over which the message was received. This is what the mainlog carries in its connection field on reception records; for the connection a delivery was attempted over, see `%OC`.
 
 </dd>
 
@@ -655,6 +655,14 @@ The text of the DSN returned by the remote server at any phase—delivery, trans
 <dd>
 
 Number of times the message has been tried
+
+</dd>
+
+<dt>%OC</dt>
+
+<dd>
+
+Outbound connection ID: the connection over which delivery was attempted. Each attempt uses a new connection, so retries of the same message log different values. This is the value the mainlog carries in its connection field on delivery, transient failure and permanent failure records. Expands empty on receptions, which have no outbound connection.
 
 </dd>
 


### PR DESCRIPTION
## What

- Adds the new `%OC` macro to the custom_logger module docs: the outbound connection ID, i.e. the value ec_logger writes in the mainlog connection field on delivery, transient-failure and permanent-failure records. Notes that each delivery attempt uses a new connection (retries log different values) and that it expands empty on receptions.
- Clarifies `%CI` as the **inbound** connection ID, with a cross-reference to `%OC`.
- Disambiguates the four "Connection ID" rows in the mainlog format reference: inbound on reception records, outbound on D/T/P records.

## Why

`%OC` is added in SparkPost/Momentum#1472 so custom log formats can reproduce the mainlog's connection field on delivery-side events without redefining `%CI`, which on-premise customers already consume as the inbound connection ID.

Note for review: `%OC` first ships in 5.3.0 — if these momentum/4 pages need a version annotation or a different home per the docs versioning convention, happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to Momentum 4 logging reference pages; no runtime or configuration behavior changes in this repo.
> 
> **Overview**
> Documents the new **`%OC`** custom_logger format macro (outbound connection ID) and clarifies how **connection ID** fields in the mainlog differ between inbound and outbound events.
> 
> In **`custom-logger.md`**, **`%CI`** is now described explicitly as the **inbound** connection ID (mainlog reception records), with a pointer to **`%OC`** for delivery-side connection IDs. **`%OC`** is added to the format specifier list: outbound connection used for a delivery attempt, matching mainlog D/T/P records, empty on receptions, and a new value per retry.
> 
> In **`log-formats-mainlog.md`**, offset-3 **Connection ID** descriptions are updated for reception (inbound), delivery, transient failure, and permanent failure (outbound, new connection per attempt).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a4458d49a94b6a8be39ab4feb05b001ecaa904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->