### PR TITLE
Point Analyst support contacts at support@bird.com

### DIFF
--- a/components/site/analystHomePageContent.tsx
+++ b/components/site/analystHomePageContent.tsx
@@ -59,7 +59,7 @@ const help = {
     </>
   ),
   content: [
-    { text: 'Submit a ticket', url: 'mailto:support@edatasource.com', Icon: Feedback },
+    { text: 'Submit a ticket', url: 'mailto:support@bird.com', Icon: Feedback },
   ],
 };
 

--- a/components/site/analystNavigation.tsx
+++ b/components/site/analystNavigation.tsx
@@ -15,7 +15,7 @@ const AnalystNavigation = (props: NavigationProps): JSX.Element | null => {
   return (
     <BaseNavigation data={data} title={title} titleLink={titleLink}>
       <Box py="450" mt="450" borderTop="400">
-        <Link href="mailto:support@edatasource.com" passHref>
+        <Link href="mailto:support@bird.com" passHref>
           <StyledLink>
             <Box px="500">
               <Feedback size={20} />

--- a/content/analyst/competitive-tracker/brand-tracker.md
+++ b/content/analyst/competitive-tracker/brand-tracker.md
@@ -70,7 +70,7 @@ description: What insights can I learn from Brand Tracker?
 
  Feel free to contact your TAM or our Support Team with any further questions!
 
-[Contact our Support Team](mailto:support@edatasource.com?subject=Question%20About%20Brand%20Tracker) 
+[Contact our Support Team](mailto:support@bird.com?subject=Question%20About%20Brand%20Tracker) 
 
 
 

--- a/content/analyst/competitive-tracker/company-tracker.md
+++ b/content/analyst/competitive-tracker/company-tracker.md
@@ -59,4 +59,4 @@ description: What insights can I learn from Company Tracker?
 
  Feel free to contact your TAM or our Support Team with any further questions!
 
-[Contact our Support Team](mailto:support@edatasource.com?subject=Question%20About%20Company%20Tracker) 
+[Contact our Support Team](mailto:support@bird.com?subject=Question%20About%20Company%20Tracker) 

--- a/content/analyst/competitive-tracker/overlap-analysis.md
+++ b/content/analyst/competitive-tracker/overlap-analysis.md
@@ -30,4 +30,4 @@ description: Identify the sending domains that you are directly competing agains
 
  Feel free to contact your TAM or our Support Team with any further questions!
 
-[Contact our Support Team](mailto:support@edatasource.com?subject=Question%20About%20Overlap%20Analysis) 
+[Contact our Support Team](mailto:support@bird.com?subject=Question%20About%20Overlap%20Analysis) 

--- a/content/analyst/competitive-tracker/sending-domain.md
+++ b/content/analyst/competitive-tracker/sending-domain.md
@@ -69,4 +69,4 @@ description: What insights can I learn from the Sending Domain page of Competiti
 
  Feel free to contact your TAM or our Support Team with any further questions!
 
-[Contact our Support Team](mailto:support@edatasource.com?subject=Question%20About%20Sending%20Domain) 
+[Contact our Support Team](mailto:support@bird.com?subject=Question%20About%20Sending%20Domain) 

--- a/content/analyst/general/api-starter-guide.md
+++ b/content/analyst/general/api-starter-guide.md
@@ -14,7 +14,7 @@ description: This article provides a brief description of Inbox Tracker API endp
 
 ### Requesting an API Key
 
- API keys are typically included in most Inbox Tracker subscriptions. You can request a key through either your Customer Success Manager, Product Support Specialist, or through support channels (via Intercom chat or by mailing [support@edatsource.com](mailto:support@edatsource.com)).
+ API keys are typically included in most Inbox Tracker subscriptions. You can request a key through either your Customer Success Manager, Product Support Specialist, or through support channels (via the in-app Support Request form or by mailing [support@bird.com](mailto:support@bird.com)).
 
  Once you send a request, we'll quickly check your contract to make sure we can provide a key. From there, an encrypted email will be sent containing the key.
 
@@ -47,7 +47,7 @@ description: This article provides a brief description of Inbox Tracker API endp
 
 ### API Questions and Support
 
- API-related questions can be answered by our support team through in-app chat or by emailing [support@edatasource.com](mailto:support@edatasource.com).
+ API-related questions can be answered by our support team through the in-app Support Request form or by emailing [support@bird.com](mailto:support@bird.com).
  
 
 

--- a/content/analyst/general/data-source-types.md
+++ b/content/analyst/general/data-source-types.md
@@ -27,7 +27,7 @@ The IntelliSeed™ List allows clients to [deploy virtual users](/analyst/inbox-
 
 Note: IntelliSeed™ results are not considered in engagement metrics.
 
-Please contact your TAM or [support@edatasource.com](mailto:support@edatasource.com) if you're interested in learning about Public IntelliSeeds™ options, which can be used across all platform products.
+Please contact your TAM or [support@bird.com](mailto:support@bird.com) if you're interested in learning about Public IntelliSeeds™ options, which can be used across all platform products.
 
 * * *
 
@@ -41,5 +41,5 @@ Note: A seed address will never engage with an email message, which makes it loo
 
 Feel free to contact your TAM or our Support Team with any further questions!
 
-[Contact our Support Team](mailto:support@edatasource.com?subject=Question%20About%20Data%20Sources)
+[Contact our Support Team](mailto:support@bird.com?subject=Question%20About%20Data%20Sources)
 

--- a/content/analyst/general/need-help-here-is-how-to-reach-us.md
+++ b/content/analyst/general/need-help-here-is-how-to-reach-us.md
@@ -21,6 +21,6 @@ description: New to the platform or just need a refresher? Check out our trainin
 
 ## Message us directly:
 
- If you have a question that can be quickly answered by our Support team, click the chat icon in the bottom, right-hand corner to message us directly. We are available during normal business hours. If you prefer to connect via email instead, send us a message at [support@edatasource.com.](mailto:support@edatasource.com) 
+ If you have a question that can be quickly answered by our Support team, click the chat icon in the bottom, right-hand corner to message us directly. We are available during normal business hours. If you prefer to connect via email instead, send us a message at [support@bird.com.](mailto:support@bird.com) 
 
 

--- a/content/analyst/inbox-and-design-tracker/analyze-and-optimize-subject-line-performance.md
+++ b/content/analyst/inbox-and-design-tracker/analyze-and-optimize-subject-line-performance.md
@@ -6,7 +6,7 @@ description: Find out how different subject line emotions and lengths affect eng
 
 ## Analyze past Subject Line performance with Subject Line Advisor, powered by Persado. Optimize future Subject Lines prior to deployment with Subject Predict.
 
-**Navigate to Subject Line Advisor within Inbox Tracker.** Not seeing it? Contact us at [support@edatasource.com](mailto:support@edatasource.com) for details.
+**Navigate to Subject Line Advisor within Inbox Tracker.** Not seeing it? Contact us at [support@bird.com](mailto:support@bird.com) for details.
 
 ![](media/analyze_and_optimize_subject_line_performance/image_0.png)
 

--- a/content/analyst/inbox-and-design-tracker/cloudmark-reputation-troubleshooting-guide.md
+++ b/content/analyst/inbox-and-design-tracker/cloudmark-reputation-troubleshooting-guide.md
@@ -54,4 +54,4 @@ description: Read on for help with Cloudmark reputation and troubleshooting pote
 
  After you have scrubbed the email's content and formatting, you can resend the campaign and see if any issues were detected.  If they are cleared they will be shown as gray numbers vs. red, and you will know your efforts have helped.
 
- If these steps have not resolved your Cloudmark issues, please reach out to the SparkPost team by sending an email to [support@edatasource.com.](mailto:support@edatasource.com) We will review your specific case and the steps you have taken toward a resolution to determine where to go next.
+ If these steps have not resolved your Cloudmark issues, please reach out to the SparkPost team by sending an email to [support@bird.com.](mailto:support@bird.com) We will review your specific case and the steps you have taken toward a resolution to determine where to go next.

--- a/content/analyst/inbox-and-design-tracker/command-center.md
+++ b/content/analyst/inbox-and-design-tracker/command-center.md
@@ -16,7 +16,7 @@ description: Command Center provides an IP-centric view of deliverability for se
 
 ![](media/command_center/image_0.png)
 
- If you'd like more information on Command Center, please reach out to your Account Manager or email us at [support@edatasource.com](mailto:support@edatasource.com).
+ If you'd like more information on Command Center, please reach out to your Account Manager or email us at [support@bird.com](mailto:support@bird.com).
  
 
 

--- a/content/analyst/inbox-and-design-tracker/how-to-auto-add-inbox-tracker-domains.md
+++ b/content/analyst/inbox-and-design-tracker/how-to-auto-add-inbox-tracker-domains.md
@@ -16,4 +16,4 @@ description: Domain Auto-Association allows you to add domains directly to Inbox
 
 **3. The domain will be added upon checking valid SPF and DKIM records. You will need to add the domain to an Inbox Tracker profile.** 
 
- Please contact us by mailing [csteam@edatasource.com](mailto:csteam@edatasource.com) if you are experiencing issues or are interested in enabling this feature on your account.
+ Please contact us by mailing [support@bird.com](mailto:support@bird.com) if you are experiencing issues or are interested in enabling this feature on your account.

--- a/content/analyst/inbox-and-design-tracker/how-to-create-an-abuse.net-listing.md
+++ b/content/analyst/inbox-and-design-tracker/how-to-create-an-abuse.net-listing.md
@@ -23,4 +23,4 @@ description: Don't have an Abuse.net listing? Here's how to create one
 
 ![](media/how_to_create_an_abusenet_listing/image_1.png)
 
- For further inquiries, reach out to [csteam@edatasource.com](mailto:csteam@edatasource.com).
+ For further inquiries, reach out to [support@bird.com](mailto:support@bird.com).

--- a/content/analyst/inbox-and-design-tracker/how-to-update-campaign-tracking-method.md
+++ b/content/analyst/inbox-and-design-tracker/how-to-update-campaign-tracking-method.md
@@ -69,4 +69,4 @@ description: Campaigns are organized by Subject Line/Date. Update your tracking 
 
  Our final option is x-mailer and is only used by a small subset of our senders.
 
- Please send an email to [support@edatasource.com](mailto:support@edatasource.com) 
+ Please send an email to [support@bird.com](mailto:support@bird.com) 

--- a/content/analyst/inbox-and-design-tracker/intelliseed-sending-guide.md
+++ b/content/analyst/inbox-and-design-tracker/intelliseed-sending-guide.md
@@ -96,4 +96,4 @@ description: An all-encompassing guide that covers everything you need to know a
 * If your email segmentation is mainly based on engagement, another way you can approach the IntelliSeeds is to take each segment (or a few segments), and take them through your welcome series as if they were a new subscriber. That way the IntelliSeeds will naturally fall into your different engagement buckets to represent each portion of your engaged (or on-engaged) audience.
 * If your mailing list requires some type of identifying information (such as zip code or past purchases), manually assign those same required attributes to IntelliSeeds™. Creativity is an asset when it comes to seeding strategy!
 
- You can reach out to our support team by mailing [support@edatasource.com](mailto:support@edatasource.com) .
+ You can reach out to our support team by mailing [support@bird.com](mailto:support@bird.com) .

--- a/content/analyst/inbox-and-design-tracker/traditional-seed-sending-guide.md
+++ b/content/analyst/inbox-and-design-tracker/traditional-seed-sending-guide.md
@@ -37,11 +37,11 @@ These missing percentages count towards spam placement on the dashboard pie char
 
 If you are seeing a regular _Missing_ percentage on all your seed sends, we recommend spot checking the delivery status to a specific seed address that is reporting the missing percentage.
 
-In the example above, since "Free.fr" is showing that all six seeds did not receive the campaign. One of those six addresses is "[lalaith.rian@free.fr](mailto:lalaith.rian@free.fr)"; check your ESP to see if they are suppressing the address for any reason and if you can override that suppression to the free.fr ISP. If the seeds are bouncing, please notify our team at [support@edatasource.com](mailto:support@edatasource.com).
+In the example above, since "Free.fr" is showing that all six seeds did not receive the campaign. One of those six addresses is "[lalaith.rian@free.fr](mailto:lalaith.rian@free.fr)"; check your ESP to see if they are suppressing the address for any reason and if you can override that suppression to the free.fr ISP. If the seeds are bouncing, please notify our team at [support@bird.com](mailto:support@bird.com).
 
 **2\. The traditional seeds should be deployed on a weekly basis.** Again, these seeds do not engage, so including these addresses on frequent sends will cause the ISPs to quickly place your emails into the spam folder. Weekly sends are a safe way to have additional data without damaging your reputation to the seed addresses. Think of a campaign in your program that deploys weekly, and simply include the traditional seeds (in their entirety) on that send for best results.
 
 **3\. Strive to include the traditional seeds in a live send for optimal results.** If you can't include them in a live send, have the send be exactly the same as it is to your regular audience. Avoid using the words _"_seed" or "test" in the subject line; ISP algorithms detect these words and they may alter the results of the send.
 
-Want help with developing a seeding strategy? Reach out to our support team by mailing [support@edatasource.com](mailto:support@edatasource.com).
+Want help with developing a seeding strategy? Reach out to our support team by mailing [support@bird.com](mailto:support@bird.com).
 

--- a/content/analyst/inbox-and-design-tracker/what-happens-if-i-go-over-my-monthly-or-annual-seed-test-design-previews-or-open-analytics-limits.md
+++ b/content/analyst/inbox-and-design-tracker/what-happens-if-i-go-over-my-monthly-or-annual-seed-test-design-previews-or-open-analytics-limits.md
@@ -40,4 +40,4 @@ description: Everything you need to know about what we do when your account reac
 
  The platform will **automatically prevent** you from running any additional design tracker tests when you reach your Design Tracker limits.
 
- If you have any additional questions on event usage and limits, please reach out to your Account Manager or email us at [support@edatasource.com](mailto:support@edatasource.com).
+ If you have any additional questions on event usage and limits, please reach out to your Account Manager or email us at [support@bird.com](mailto:support@bird.com).


### PR DESCRIPTION
## Summary
Every documented way to reach support from the Inbox Tracker docs led to a retired eDataSource mailbox, and the chat references pointed at a widget the Analyst UI no longer has. All support addresses in the Analyst content and site chrome are now `support@bird.com`, and the API Starter Guide names the in-app Support Request form in place of chat. Content and link changes only. Refs SparkPost/analyst-ng#12520.

## Changes
- `content/analyst/general/api-starter-guide.md`: "Requesting an API Key" now says the key can be requested "via the in-app Support Request form or by mailing support@bird.com" (was "via Intercom chat or by mailing support@edatsource.com" — the old address was also misspelled). "API Questions and Support" now says "through the in-app Support Request form or by emailing support@bird.com".
- 14 further Analyst articles: `support@edatasource.com` → `support@bird.com` in body text and `mailto:` links, including the `?subject=` prefilled "Contact our Support Team" links in the Competitive Tracker pages and Data Source Types.
- `how-to-create-an-abuse.net-listing.md` and `how-to-auto-add-inbox-tracker-domains.md`: `csteam@edatasource.com` → `support@bird.com`.
- `components/site/analystNavigation.tsx` and `components/site/analystHomePageContent.tsx`: the Analyst "Submit a Ticket" / "Submit a ticket" links point at `mailto:support@bird.com`.

## Testing
- `git diff --stat` — 18 files, 21 insertions, 21 deletions.
- `grep -rn "edatasource.com\|edatsource" content/analyst components/site` returns no remaining email addresses. The remaining hits are web links (`api.edatasource.com`, `status.edatasource.com`, `www.edatasource.com`), which still resolve and are out of scope here.
- No build or lint run: the repo has no `node_modules` in a fresh clone, and both component edits change a single string literal inside an existing `href`/`url` field.

## Notes
- `lastUpdated` frontmatter is unchanged, matching how recent content edits in this repo were made.
- `need-help-here-is-how-to-reach-us.md` still tells readers to "click the chat icon in the bottom, right-hand corner"; the Analyst UI has no chat widget. Only its email address is fixed here — the page needs a rewrite of that section.
- The eDataSource web links above are left as-is; retargeting them is a separate decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and markdown link updates only; no application logic, auth, or data handling.
> 
> **Overview**
> Analyst help content and site chrome still directed users to retired **eDataSource** mailboxes (`support@edatasource.com`, `csteam@edatasource.com`, and a misspelled `support@edatsource.com` in the API guide). This PR retargets those touchpoints to **`support@bird.com`**.
> 
> **Site UI:** The Analyst home “Submit a ticket” action and navigation **Submit a Ticket** `mailto:` links now use `support@bird.com`.
> 
> **Docs:** Competitive Tracker articles, general help pages, and Inbox/Design Tracker how-tos update inline support addresses and prefilled **Contact our Support Team** links. The **API Starter Guide** also replaces **Intercom chat** wording with the **in-app Support Request form** alongside the new email.
> 
> Content and string-only link changes; API/status **edatasource.com** web URLs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b65c5c4fc31eb1c71c5ef03f7112e9f7ed92aa52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->