### PR TITLE
analyst-ng#12518 stop documenting SNDS trap hits Microsoft no longer reports

### DIFF
--- a/content/analyst/inbox-and-design-tracker/microsoft-snds-set-up-and-configuration.md
+++ b/content/analyst/inbox-and-design-tracker/microsoft-snds-set-up-and-configuration.md
@@ -41,7 +41,9 @@ description: Everything you need to know about setting up Outlook SNDS and synci
 
  For example, if you notice low deliverability rates to Outlook within Inbox Tracker, you should first check how much panel coverage the campaign(s) have. From there, SNDS can be used as a confirmation of whether a send was or was not well received.
 
- SNDS configuration also unlocks two additional metrics within the platform: The number of Outlook spam complaints (Dashboard) and SNDS trap hits (Spam Trap Monitor).
+ SNDS configuration also unlocks an additional metric within the platform: the number of Outlook spam complaints (Dashboard).
+
+*Microsoft stopped including spam trap hit counts in the SNDS Data Report on July 22, 2026, and offers no replacement for that data. SNDS trap hits are no longer shown in Spam Trap Monitor. Everything else SNDS reports — filter results, send volume, complaint rate and IP status — is unaffected.*
 
 ![](media/microsoft_snds_set_up_and_configuration/image_1.png)
 

--- a/content/analyst/inbox-and-design-tracker/spam-trap-types-and-sources.md
+++ b/content/analyst/inbox-and-design-tracker/spam-trap-types-and-sources.md
@@ -25,8 +25,6 @@ description: Spam trap type and source overview
 
 ***Cloudmark*** - a trusted leader in intelligent threat protection against known and future attacks, safeguarding 12 percent of the world's inboxes and 20 percent of mobile accounts from wide-scale and targeted email threats.
 
-***SNDS*** - The Outlook.com Smart Network Data Services (SNDS) gives you the data you need to understand and improve your reputation at Outlook.com.
-
 ***Global Trap Network (GTN) - Passive -*** The passive network, uses proprietary data science techniques to detect the domains on other providers’ active networks. It can identify when senders using the SparkPost platform are sending to those networks without the customer needing a relationship with those other providers.
 
 ***Global Trap Network (GTN) - Active*** - Proprietary spam trap network maintained by Sparkpost. These traps will not affect your reputation but can be used to gauge the effectiveness of your list management and hygiene practices.


### PR DESCRIPTION
## Summary
Microsoft stopped including spam trap hit counts in the SNDS Data Report on 2026-07-22 and offers no replacement signal, so SNDS is no longer a spam trap source in the platform. These docs still promised customers that data. Everything else SNDS reports — filter results, send volume, complaint rate and IP status — is unaffected and stays documented.

Refs SparkPost/analyst-ng#12518. Platform change: SparkPost/analyst-ng#12519.

## Changes
- `microsoft-snds-set-up-and-configuration.md`: SNDS configuration now unlocks one additional metric (Outlook spam complaints), not two. Adds a note that Microsoft stopped reporting trap hits on July 22, 2026, so a customer who linked the feed for trap visibility can see the capability was withdrawn upstream.
- `spam-trap-types-and-sources.md`: removes SNDS from the Trap Sources list.

## Notes
- **Do not merge until SparkPost/analyst-ng#12519 is deployed to production.** Docs lagging the platform is fine; docs describing a removal that has not shipped is not.
- `inbox-tracker-reference-guide.md` also mentions SNDS, deliberately left unchanged: its content covers spam verdicts and sender reputation, not trap hits.
- Screenshots under `media/microsoft_snds_set_up_and_configuration/` were checked and none show SNDS trap data, so no images need replacing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analyst help content only; no application or data-handling code changes.
> 
> **Overview**
> **Documentation now matches Microsoft’s July 22, 2026 change:** SNDS no longer supplies spam trap hit counts, and the platform no longer surfaces SNDS trap data in Spam Trap Monitor.
> 
> In **Microsoft SNDS - Set Up and Configuration**, SNDS setup is described as unlocking **one** extra Dashboard metric (Outlook spam complaints), not two. A short note explains that trap hits were dropped from the SNDS Data Report with no replacement, while filter results, volume, complaint rate, and IP status remain documented.
> 
> In **Spam Trap Types and Sources**, **SNDS is removed** from the Trap Sources list so customers are not told Outlook SNDS is still a trap feed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6fa4783060e665bbf7b1ffa9781b92fc60d667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->